### PR TITLE
fix: update org references from jonasthim to dilla-chat

### DIFF
--- a/.github/CLAUDE_TRACKING.md
+++ b/.github/CLAUDE_TRACKING.md
@@ -72,12 +72,12 @@ gh pr list --author "Claude" --state all --json number,title,state,url,body,merg
 ### Method 3: Using GitHub Web UI
 
 #### Find auto-fix issues:
-1. Go to the [Issues page](https://github.com/jonasthim/dilla-chat/issues)
+1. Go to the [Issues page](https://github.com/dilla-chat/dilla-chat/issues)
 2. Click on "Labels" and select `auto-fix`
 3. Or use this search query: `is:issue label:auto-fix`
 
 #### Find Claude PRs:
-1. Go to the [Pull Requests page](https://github.com/jonasthim/dilla-chat/pulls)
+1. Go to the [Pull Requests page](https://github.com/dilla-chat/dilla-chat/pulls)
 2. Use this search query: `is:pr author:app/anthropic-code-agent`
 3. Or filter by author: `Claude`
 
@@ -86,14 +86,14 @@ gh pr list --author "Claude" --state all --json number,title,state,url,body,merg
 #### Get auto-fix issues:
 ```bash
 curl -H "Authorization: token YOUR_TOKEN" \
-  "https://api.github.com/repos/jonasthim/dilla-chat/issues?labels=auto-fix&state=all"
+  "https://api.github.com/repos/dilla-chat/dilla-chat/issues?labels=auto-fix&state=all"
 ```
 
 #### Get Claude PRs:
 ```bash
 # Note: Claude's GitHub user ID is 242468646
 curl -H "Authorization: token YOUR_TOKEN" \
-  "https://api.github.com/repos/jonasthim/dilla-chat/pulls?state=all" \
+  "https://api.github.com/repos/dilla-chat/dilla-chat/pulls?state=all" \
   | jq '.[] | select(.user.id == 242468646)'
 ```
 
@@ -278,21 +278,21 @@ echo "$metrics" | jq '.'
 
 1. Verify GitHub CLI is installed: `gh --version`
 2. Verify authentication: `gh auth status`
-3. Verify repository access: `gh repo view jonasthim/dilla-chat`
+3. Verify repository access: `gh repo view dilla-chat/dilla-chat`
 
 ### Wrong Repository
 
 Set the repository explicitly:
 
 ```bash
-export GITHUB_REPOSITORY="jonasthim/dilla-chat"
+export GITHUB_REPOSITORY="dilla-chat/dilla-chat"
 .github/scripts/list-claude-issues.sh
 ```
 
 Or use gh with repo flag:
 
 ```bash
-gh issue list --repo jonasthim/dilla-chat --label "auto-fix"
+gh issue list --repo dilla-chat/dilla-chat --label "auto-fix"
 ```
 
 ## See Also

--- a/.github/scripts/list-claude-issues.py
+++ b/.github/scripts/list-claude-issues.py
@@ -27,7 +27,7 @@ def extract_fixed_issues(pr_body: str) -> List[int]:
         return []
 
     # Look for patterns like "Closes #123", "Fixes #123", "Resolves #123"
-    pattern = r'(?:Closes?|Fixes?|Resolves?)\s+(?:#|jonasthim/dilla-chat#)(\d+)'
+    pattern = r'(?:Closes?|Fixes?|Resolves?)\s+(?:#|dilla-chat/dilla-chat#)(\d+)'
     matches = re.findall(pattern, pr_body, re.IGNORECASE)
     return [int(m) for m in matches]
 
@@ -144,7 +144,7 @@ def main():
     print("    from github import Github", file=sys.stderr)
     print("    ", file=sys.stderr)
     print("    g = Github('your_token_here')", file=sys.stderr)
-    print("    repo = g.get_repo('jonasthim/dilla-chat')", file=sys.stderr)
+    print("    repo = g.get_repo('dilla-chat/dilla-chat')", file=sys.stderr)
     print("    ", file=sys.stderr)
     print("    # Get auto-fix issues", file=sys.stderr)
     print("    autofix_issues = repo.get_issues(labels=['auto-fix'], state='all')", file=sys.stderr)
@@ -162,7 +162,7 @@ def main():
             'title': '[Auto-fix] Client lint errors detected',
             'state': 'open',
             'labels': [{'name': 'auto-fix'}, {'name': 'lint'}, {'name': 'client'}],
-            'url': 'https://github.com/jonasthim/dilla-chat/issues/4'
+            'url': 'https://github.com/dilla-chat/dilla-chat/issues/4'
         }
     ]
 
@@ -172,8 +172,8 @@ def main():
             'title': '[Auto-fix] Fix client lint errors detected',
             'state': 'closed',
             'merged_at': '2026-03-16T19:44:49Z',
-            'url': 'https://github.com/jonasthim/dilla-chat/pull/7',
-            'body': '... Fixes jonasthim/dilla-chat#4'
+            'url': 'https://github.com/dilla-chat/dilla-chat/pull/7',
+            'body': '... Fixes dilla-chat/dilla-chat#4'
         }
     ]
 

--- a/.github/scripts/list-claude-issues.sh
+++ b/.github/scripts/list-claude-issues.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 # Default values
 STATE="open"
 FORMAT="text"
-REPO="${GITHUB_REPOSITORY:-jonasthim/dilla-chat}"
+REPO="${GITHUB_REPOSITORY:-dilla-chat/dilla-chat}"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- Updated all hardcoded `jonasthim/dilla-chat` references to `dilla-chat/dilla-chat` after org migration
- Affected files: `.github/CLAUDE_TRACKING.md`, `.github/scripts/list-claude-issues.sh`, `.github/scripts/list-claude-issues.py`

## Manual actions still needed
Two CI failures on main require **repo settings** changes (not code):

1. **CodeQL Analysis** — Go language no longer exists in the codebase. Remove Go from CodeQL at [Settings > Code Security](https://github.com/dilla-chat/dilla-chat/settings/code-security-and-analysis)
2. **GitHub Pages** — Enable Pages with source "GitHub Actions" at [Settings > Pages](https://github.com/dilla-chat/dilla-chat/settings/pages)

## Verification
```bash
grep -r "jonasthim" .github/   # should return no results
```