### PR TITLE
refactor: replace 9 untyped hub callbacks with typed HubEvent enum

### DIFF
--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -157,46 +157,42 @@ async fn main() {
     presence_mgr.start_idle_checker(std::time::Duration::from_secs(30));
     let presence_mgr = Arc::new(presence_mgr);
 
-    // Wire hub callbacks to presence manager.
-    let pm = presence_mgr.clone();
-    *hub.on_client_connect.write().await = Some(Box::new(move |user_id| {
-        let pm = pm.clone();
-        let uid = user_id.to_string();
-        tokio::spawn(async move { pm.set_online(&uid).await });
-    }));
-
-    let pm = presence_mgr.clone();
-    *hub.on_client_disconnect.write().await = Some(Box::new(move |user_id| {
-        let pm = pm.clone();
-        let uid = user_id.to_string();
-        tokio::spawn(async move { pm.set_offline(&uid).await });
-    }));
-
-    let pm = presence_mgr.clone();
-    *hub.on_client_activity.write().await = Some(Box::new(move |user_id| {
-        let pm = pm.clone();
-        let uid = user_id.to_string();
-        tokio::spawn(async move { pm.update_activity(&uid).await });
-    }));
-
-    let pm = presence_mgr.clone();
-    let db_pres = database.clone();
-    *hub.on_presence_update.write().await =
-        Some(Box::new(move |user_id, status_type, custom_status| {
-            let pm = pm.clone();
-            let uid = user_id.to_string();
-            let st = status_type.to_string();
-            let cs = custom_status.to_string();
-            let db = db_pres.clone();
-            tokio::spawn(async move {
-                pm.update_presence(&uid, presence::Status::from_str(&st), &cs)
-                    .await;
-                let _ = tokio::task::spawn_blocking(move || {
-                    db.with_conn(|conn| db::update_user_status(conn, &uid, &st, &cs))
-                })
-                .await;
-            });
-        }));
+    // Subscribe to hub events and handle presence updates.
+    {
+        let pm = presence_mgr.clone();
+        let db_evt = database.clone();
+        let mut event_rx = hub.event_tx().subscribe();
+        tokio::spawn(async move {
+            while let Ok(event) = event_rx.recv().await {
+                match event {
+                    ws::hub::HubEvent::ClientConnected { user_id } => {
+                        pm.set_online(&user_id).await;
+                    }
+                    ws::hub::HubEvent::ClientDisconnected { user_id } => {
+                        pm.set_offline(&user_id).await;
+                    }
+                    ws::hub::HubEvent::ClientActivity { user_id } => {
+                        pm.update_activity(&user_id).await;
+                    }
+                    ws::hub::HubEvent::PresenceUpdate { user_id, status, custom_status } => {
+                        pm.update_presence(&user_id, presence::Status::from_str(&status), &custom_status)
+                            .await;
+                        let db = db_evt.clone();
+                        let uid = user_id.clone();
+                        let st = status.clone();
+                        let cs = custom_status.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            db.with_conn(|conn| db::update_user_status(conn, &uid, &st, &cs))
+                        })
+                        .await;
+                    }
+                    // MessageSent, MessageEdited, MessageDeleted, VoiceJoined, VoiceLeft
+                    // are available for federation subscribers to consume.
+                    _ => {}
+                }
+            }
+        });
+    }
 
     // Start federation mesh node (if peers or federation port configured).
     let mesh = if !cfg.peers.is_empty() || !cfg.node_name.is_empty() {

--- a/server-rs/src/ws/client.rs
+++ b/server-rs/src/ws/client.rs
@@ -73,9 +73,7 @@ pub async fn handle_ws_connection(
                     }
 
                     // Notify activity.
-                    if let Some(cb) = hub_read.on_client_activity.read().await.as_ref() {
-                        cb(&uid);
-                    }
+                    hub_read.emit_event(super::hub::HubEvent::ClientActivity { user_id: uid.clone() });
 
                     if let Ok(event) = serde_json::from_str::<Event>(&text) {
                         handle_event(&hub_read, &cid_read, &uid, &uname, &tid, event).await;
@@ -138,9 +136,11 @@ async fn handle_event(
         }
         EVENT_PRESENCE_UPDATE => {
             if let Ok(p) = serde_json::from_value::<PresenceUpdatePayload>(event.payload) {
-                if let Some(cb) = hub.on_presence_update.read().await.as_ref() {
-                    cb(user_id, &p.status_type, &p.status_text);
-                }
+                hub.emit_event(super::hub::HubEvent::PresenceUpdate {
+                    user_id: user_id.to_string(),
+                    status: p.status_type.clone(),
+                    custom_status: p.status_text.clone(),
+                });
             }
         }
         EVENT_PING => {

--- a/server-rs/src/ws/handlers/message.rs
+++ b/server-rs/src/ws/handlers/message.rs
@@ -99,9 +99,10 @@ pub(in crate::ws) async fn handle_message_send(
         }
     }
 
-    if let Some(cb) = hub.on_message_send.read().await.as_ref() {
-        cb(&msg, username);
-    }
+    hub.emit_event(crate::ws::hub::HubEvent::MessageSent {
+        message: msg,
+        team_id: team_id.to_string(),
+    });
 }
 
 pub(in crate::ws) async fn handle_message_edit(hub: &Hub, user_id: &str, payload: serde_json::Value) {
@@ -143,9 +144,11 @@ pub(in crate::ws) async fn handle_message_edit(hub: &Hub, user_id: &str, payload
         }
     }
 
-    if let Some(cb) = hub.on_message_edit.read().await.as_ref() {
-        cb(&p.message_id, &p.channel_id, &p.content);
-    }
+    hub.emit_event(crate::ws::hub::HubEvent::MessageEdited {
+        message_id: p.message_id.clone(),
+        channel_id: p.channel_id.clone(),
+        content: p.content.clone(),
+    });
 }
 
 pub(in crate::ws) async fn handle_message_delete(hub: &Hub, user_id: &str, payload: serde_json::Value) {
@@ -186,9 +189,10 @@ pub(in crate::ws) async fn handle_message_delete(hub: &Hub, user_id: &str, paylo
         }
     }
 
-    if let Some(cb) = hub.on_message_delete.read().await.as_ref() {
-        cb(&p.message_id, &p.channel_id);
-    }
+    hub.emit_event(crate::ws::hub::HubEvent::MessageDeleted {
+        message_id: p.message_id.clone(),
+        channel_id: p.channel_id.clone(),
+    });
 }
 
 pub(in crate::ws) async fn handle_typing(

--- a/server-rs/src/ws/handlers/voice.rs
+++ b/server-rs/src/ws/handlers/voice.rs
@@ -70,9 +70,11 @@ pub(in crate::ws) async fn handle_voice_join(
             }
         }
 
-        if let Some(cb) = hub.on_voice_join.read().await.as_ref() {
-            cb(&p.channel_id, user_id, username);
-        }
+        hub.emit_event(crate::ws::hub::HubEvent::VoiceJoined {
+            channel_id: p.channel_id.clone(),
+            user_id: user_id.to_string(),
+            team_id: team_id.to_string(),
+        });
     }
 }
 
@@ -105,9 +107,10 @@ pub(in crate::ws) async fn handle_voice_leave(
 
     hub.unsubscribe(client_id, &p.channel_id).await;
 
-    if let Some(cb) = hub.on_voice_leave.read().await.as_ref() {
-        cb(&p.channel_id, user_id);
-    }
+    hub.emit_event(crate::ws::hub::HubEvent::VoiceLeft {
+        channel_id: p.channel_id.clone(),
+        user_id: user_id.to_string(),
+    });
 }
 
 pub(in crate::ws) async fn handle_voice_answer(hub: &Hub, user_id: &str, p: VoiceAnswerPayload) {

--- a/server-rs/src/ws/hub.rs
+++ b/server-rs/src/ws/hub.rs
@@ -2,7 +2,21 @@ use crate::db::Database;
 use crate::voice::RoomManager;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum HubEvent {
+    ClientConnected { user_id: String },
+    ClientDisconnected { user_id: String },
+    ClientActivity { user_id: String },
+    PresenceUpdate { user_id: String, status: String, custom_status: String },
+    MessageSent { message: crate::db::Message, team_id: String },
+    MessageEdited { message_id: String, channel_id: String, content: String },
+    MessageDeleted { message_id: String, channel_id: String },
+    VoiceJoined { channel_id: String, user_id: String, team_id: String },
+    VoiceLeft { channel_id: String, user_id: String },
+}
 
 pub type ClientSender = mpsc::UnboundedSender<Vec<u8>>;
 
@@ -71,21 +85,7 @@ pub struct Hub {
     broadcast_all_tx: mpsc::Sender<Vec<u8>>,
     broadcast_all_rx: tokio::sync::Mutex<mpsc::Receiver<Vec<u8>>>,
 
-    // Callbacks (set by main).
-    pub on_message_send:
-        RwLock<Option<Box<dyn Fn(&crate::db::Message, &str) + Send + Sync>>>,
-    pub on_message_edit:
-        RwLock<Option<Box<dyn Fn(&str, &str, &str) + Send + Sync>>>,
-    pub on_message_delete:
-        RwLock<Option<Box<dyn Fn(&str, &str) + Send + Sync>>>,
-    pub on_client_connect: RwLock<Option<Box<dyn Fn(&str) + Send + Sync>>>,
-    pub on_client_disconnect: RwLock<Option<Box<dyn Fn(&str) + Send + Sync>>>,
-    pub on_client_activity: RwLock<Option<Box<dyn Fn(&str) + Send + Sync>>>,
-    pub on_presence_update:
-        RwLock<Option<Box<dyn Fn(&str, &str, &str) + Send + Sync>>>,
-    pub on_voice_join:
-        RwLock<Option<Box<dyn Fn(&str, &str, &str) + Send + Sync>>>,
-    pub on_voice_leave: RwLock<Option<Box<dyn Fn(&str, &str) + Send + Sync>>>,
+    event_tx: broadcast::Sender<HubEvent>,
 }
 
 impl Hub {
@@ -97,6 +97,7 @@ impl Hub {
         let (broadcast_tx, broadcast_rx) = mpsc::channel(256);
         let (direct_tx, direct_rx) = mpsc::channel(256);
         let (broadcast_all_tx, broadcast_all_rx) = mpsc::channel(256);
+        let (event_tx, _) = broadcast::channel(256);
 
         Hub {
             db,
@@ -120,15 +121,7 @@ impl Hub {
             direct_rx: tokio::sync::Mutex::new(direct_rx),
             broadcast_all_tx,
             broadcast_all_rx: tokio::sync::Mutex::new(broadcast_all_rx),
-            on_message_send: RwLock::new(None),
-            on_message_edit: RwLock::new(None),
-            on_message_delete: RwLock::new(None),
-            on_client_connect: RwLock::new(None),
-            on_client_disconnect: RwLock::new(None),
-            on_client_activity: RwLock::new(None),
-            on_presence_update: RwLock::new(None),
-            on_voice_join: RwLock::new(None),
-            on_voice_leave: RwLock::new(None),
+            event_tx,
         }
     }
 
@@ -153,9 +146,7 @@ impl Hub {
                         .or_default()
                         .push(client_id);
 
-                    if let Some(cb) = self.on_client_connect.read().await.as_ref() {
-                        cb(&user_id);
-                    }
+                    self.emit_event(HubEvent::ClientConnected { user_id });
                 }
                 Some(client_id) = unregister_rx.recv() => {
                     let mut clients = self.clients.write().await;
@@ -171,9 +162,7 @@ impl Hub {
                                 // Last connection for this user — notify disconnect.
                                 drop(idx);
                                 drop(clients);
-                                if let Some(cb) = self.on_client_disconnect.read().await.as_ref() {
-                                    cb(&user_id);
-                                }
+                                self.emit_event(HubEvent::ClientDisconnected { user_id });
                             }
                         }
 
@@ -295,6 +284,14 @@ impl Hub {
 
     pub fn typing_throttle(&self) -> &Arc<RwLock<HashMap<String, i64>>> {
         &self.typing_throttle
+    }
+
+    pub fn emit_event(&self, event: HubEvent) {
+        let _ = self.event_tx.send(event);
+    }
+
+    pub fn event_tx(&self) -> broadcast::Sender<HubEvent> {
+        self.event_tx.clone()
     }
 }
 
@@ -761,16 +758,12 @@ mod tests {
         assert_eq!(throttle.get("u1:chan-a"), Some(&12345));
     }
 
-    // ── callbacks ─────────────────────────────────────────────────────────
+    // ── hub events ──────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn on_client_connect_callback_fires_on_register() {
+    async fn client_connected_event_fires_on_register() {
         let hub = test_hub();
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        *hub.on_client_connect.write().await = Some(Box::new(move |user_id: &str| {
-            let _ = tx.send(user_id.to_string());
-        }));
+        let mut event_rx = hub.event_tx().subscribe();
 
         let _handle = spawn_hub(&hub);
 
@@ -778,21 +771,20 @@ mod tests {
         hub.register(client).await;
         settle().await;
 
-        let uid = timeout(Duration::from_millis(100), rx.recv())
+        let evt = timeout(Duration::from_millis(100), event_rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(uid, "u1");
+        match evt {
+            super::HubEvent::ClientConnected { user_id } => assert_eq!(user_id, "u1"),
+            other => panic!("expected ClientConnected, got {:?}", other),
+        }
     }
 
     #[tokio::test]
-    async fn on_client_disconnect_fires_when_last_client_removed() {
+    async fn client_disconnected_event_fires_when_last_client_removed() {
         let hub = test_hub();
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        *hub.on_client_disconnect.write().await = Some(Box::new(move |user_id: &str| {
-            let _ = tx.send(user_id.to_string());
-        }));
+        let mut event_rx = hub.event_tx().subscribe();
 
         let _handle = spawn_hub(&hub);
 
@@ -802,22 +794,29 @@ mod tests {
         hub.register(c2).await;
         settle().await;
 
+        // Drain connect events.
+        let _ = timeout(Duration::from_millis(50), event_rx.recv()).await;
+        let _ = timeout(Duration::from_millis(50), event_rx.recv()).await;
+
         // Remove first client — should NOT fire disconnect (user still has c2).
         hub.unregister("c1").await;
         settle().await;
 
-        let result = timeout(Duration::from_millis(50), rx.recv()).await;
+        let result = timeout(Duration::from_millis(50), event_rx.recv()).await;
         assert!(result.is_err(), "disconnect should not fire while user has active connections");
 
         // Remove last client — SHOULD fire disconnect.
         hub.unregister("c2").await;
         settle().await;
 
-        let uid = timeout(Duration::from_millis(100), rx.recv())
+        let evt = timeout(Duration::from_millis(100), event_rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(uid, "u1");
+        match evt {
+            super::HubEvent::ClientDisconnected { user_id } => assert_eq!(user_id, "u1"),
+            other => panic!("expected ClientDisconnected, got {:?}", other),
+        }
     }
 
     // ── subscribe after unregister ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replace 9 untyped callback closures (`Fn(&str, &str, &str)`) with a typed `HubEvent` enum and broadcast channel.

**Before:** 9 `RwLock<Option<Box<dyn Fn(&str, &str, &str)>>>` fields where parameters were ambiguous — which `&str` is user_id vs channel_id vs content?

**After:** One `broadcast::Sender<HubEvent>` with typed variants:
```rust
pub enum HubEvent {
    ClientConnected { user_id: String },
    ClientDisconnected { user_id: String },
    PresenceUpdate { user_id: String, status: String, custom_status: String },
    MessageSent { message: Message, team_id: String },
    // ... 5 more variants
}
```

- `hub.emit_event(HubEvent::X { ... })` replaces `hub.on_X.read().await.as_ref().map(|cb| cb(...))`
- main.rs subscribes in one spawned task instead of 4 separate callback assignments
- Federation consumers can subscribe to the same broadcast channel

## Test plan

- [x] `cargo check` — 0 errors, 0 warnings
- [x] `cargo test` — 289/289 pass

Addresses architectural issue #5 from the code review.