### PR TITLE
feat: add last-writer-wins conflict resolution to federation sync

### DIFF
--- a/server-rs/migrations/006_federation_sync.sql
+++ b/server-rs/migrations/006_federation_sync.sql
@@ -1,0 +1,3 @@
+-- Add updated_at to roles and members for federation conflict resolution.
+ALTER TABLE roles ADD COLUMN updated_at TEXT DEFAULT '';
+ALTER TABLE members ADD COLUMN updated_at TEXT DEFAULT '';

--- a/server-rs/src/api/auth_handlers.rs
+++ b/server-rs/src/api/auth_handlers.rs
@@ -201,6 +201,7 @@ pub async fn register(
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: invite.created_by.clone(),
+                updated_at: String::new(),
             };
             db::create_member(conn, &member)?;
 
@@ -343,6 +344,7 @@ pub async fn bootstrap(
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: String::new(),
+                updated_at: String::new(),
             };
             db::create_member(conn, &member)?;
 
@@ -356,6 +358,7 @@ pub async fn bootstrap(
                 permissions: db::PERM_SEND_MESSAGES | db::PERM_CREATE_INVITES,
                 is_default: true,
                 created_at: now.clone(),
+                updated_at: String::new(),
             };
             db::create_role(conn, &role)?;
 

--- a/server-rs/src/api/mod.rs
+++ b/server-rs/src/api/mod.rs
@@ -426,6 +426,7 @@ mod tests {
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: String::new(),
+                updated_at: String::new(),
             })?;
             // Create admin role with all permissions.
             let role_id = db::new_id();
@@ -445,6 +446,7 @@ mod tests {
                     | db::PERM_MANAGE_TEAM,
                 is_default: true,
                 created_at: now.clone(),
+                updated_at: String::new(),
             })?;
             // Assign role to member.
             let member = db::get_member_by_user_and_team(conn, &user_id, &team_id)?.unwrap();
@@ -1355,6 +1357,7 @@ mod tests {
                 nickname: String::new(),
                 joined_at: now,
                 invited_by: user_id.clone(),
+                updated_at: String::new(),
             })
         })
         .unwrap();

--- a/server-rs/src/api/roles.rs
+++ b/server-rs/src/api/roles.rs
@@ -101,6 +101,7 @@ pub async fn create(
                 permissions: body.permissions,
                 is_default: false,
                 created_at: db::now_str(),
+                updated_at: String::new(),
             };
             db::create_role(conn, &role)?;
             Ok(role)

--- a/server-rs/src/api/teams.rs
+++ b/server-rs/src/api/teams.rs
@@ -90,6 +90,7 @@ pub async fn create(
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: String::new(),
+                updated_at: String::new(),
             };
             db::create_member(conn, &member)?;
 
@@ -103,6 +104,7 @@ pub async fn create(
                 permissions: db::PERM_SEND_MESSAGES | db::PERM_CREATE_INVITES,
                 is_default: true,
                 created_at: now.clone(),
+                updated_at: String::new(),
             };
             db::create_role(conn, &role)?;
 

--- a/server-rs/src/db/mod.rs
+++ b/server-rs/src/db/mod.rs
@@ -23,6 +23,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("003_dm_enhancements.sql", include_str!("../../migrations/003_dm_enhancements.sql")),
     ("004_threads.sql", include_str!("../../migrations/004_threads.sql")),
     ("005_reactions_attachments.sql", include_str!("../../migrations/005_reactions_attachments.sql")),
+    ("006_federation_sync.sql", include_str!("../../migrations/006_federation_sync.sql")),
 ];
 
 /// Default number of read connections in the pool.

--- a/server-rs/src/db/models.rs
+++ b/server-rs/src/db/models.rs
@@ -38,6 +38,8 @@ pub struct Role {
     pub permissions: i64,
     pub is_default: bool,
     pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,6 +50,8 @@ pub struct Member {
     pub nickname: String,
     pub joined_at: String,
     pub invited_by: String,
+    #[serde(default)]
+    pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/server-rs/src/db/queries.rs
+++ b/server-rs/src/db/queries.rs
@@ -260,8 +260,13 @@ fn row_to_channel(row: &rusqlite::Row) -> Result<Channel, rusqlite::Error> {
 // ── Member queries ──────────────────────────────────────────────────────────
 
 pub fn create_member(conn: &Connection, member: &Member) -> Result<(), rusqlite::Error> {
+    let updated = if member.updated_at.is_empty() {
+        member.joined_at.clone()
+    } else {
+        member.updated_at.clone()
+    };
     conn.execute(
-        "INSERT INTO members (id, team_id, user_id, nickname, joined_at, invited_by) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        "INSERT INTO members (id, team_id, user_id, nickname, joined_at, invited_by, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             member.id,
             member.team_id,
@@ -269,6 +274,7 @@ pub fn create_member(conn: &Connection, member: &Member) -> Result<(), rusqlite:
             member.nickname,
             member.joined_at,
             member.invited_by,
+            updated,
         ],
     )?;
     Ok(())
@@ -279,7 +285,7 @@ pub fn get_members_by_team(
     team_id: &str,
 ) -> Result<Vec<(Member, User)>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT m.id, m.team_id, m.user_id, m.nickname, m.joined_at, m.invited_by,
+        "SELECT m.id, m.team_id, m.user_id, m.nickname, m.joined_at, m.invited_by, m.updated_at,
                 u.id, u.username, u.display_name, u.public_key, u.avatar_url, u.status_text, u.status_type, u.is_admin, u.created_at, u.updated_at
          FROM members m
          JOIN users u ON u.id = m.user_id
@@ -293,18 +299,19 @@ pub fn get_members_by_team(
             nickname: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
             joined_at: row.get(4)?,
             invited_by: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+            updated_at: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
         };
         let user = User {
-            id: row.get(6)?,
-            username: row.get(7)?,
-            display_name: row.get(8)?,
-            public_key: row.get(9)?,
-            avatar_url: row.get::<_, Option<String>>(10)?.unwrap_or_default(),
-            status_text: row.get::<_, Option<String>>(11)?.unwrap_or_default(),
-            status_type: row.get::<_, Option<String>>(12)?.unwrap_or("online".into()),
-            is_admin: row.get::<_, i32>(13)? != 0,
-            created_at: row.get(14)?,
-            updated_at: row.get(15)?,
+            id: row.get(7)?,
+            username: row.get(8)?,
+            display_name: row.get(9)?,
+            public_key: row.get(10)?,
+            avatar_url: row.get::<_, Option<String>>(11)?.unwrap_or_default(),
+            status_text: row.get::<_, Option<String>>(12)?.unwrap_or_default(),
+            status_type: row.get::<_, Option<String>>(13)?.unwrap_or("online".into()),
+            is_admin: row.get::<_, i32>(14)? != 0,
+            created_at: row.get(15)?,
+            updated_at: row.get(16)?,
         };
         Ok((member, user))
     })?;
@@ -317,7 +324,7 @@ pub fn get_member_by_user_and_team(
     team_id: &str,
 ) -> Result<Option<Member>, rusqlite::Error> {
     conn.query_row(
-        "SELECT id, team_id, user_id, nickname, joined_at, invited_by FROM members WHERE user_id = ?1 AND team_id = ?2",
+        "SELECT id, team_id, user_id, nickname, joined_at, invited_by, updated_at FROM members WHERE user_id = ?1 AND team_id = ?2",
         params![user_id, team_id],
         |row| {
             Ok(Member {
@@ -327,6 +334,7 @@ pub fn get_member_by_user_and_team(
                 nickname: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
                 joined_at: row.get(4)?,
                 invited_by: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+                updated_at: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
             })
         },
     )
@@ -335,8 +343,8 @@ pub fn get_member_by_user_and_team(
 
 pub fn update_member(conn: &Connection, member: &Member) -> Result<(), rusqlite::Error> {
     conn.execute(
-        "UPDATE members SET nickname = ?1 WHERE id = ?2",
-        params![member.nickname, member.id],
+        "UPDATE members SET nickname = ?1, updated_at = ?2 WHERE id = ?3",
+        params![member.nickname, now_str(), member.id],
     )?;
     Ok(())
 }
@@ -455,9 +463,14 @@ fn row_to_message(row: &rusqlite::Row) -> Result<Message, rusqlite::Error> {
 // ── Role queries ────────────────────────────────────────────────────────────
 
 pub fn create_role(conn: &Connection, role: &Role) -> Result<(), rusqlite::Error> {
+    let updated = if role.updated_at.is_empty() {
+        now_str()
+    } else {
+        role.updated_at.clone()
+    };
     conn.execute(
-        "INSERT INTO roles (id, team_id, name, color, position, permissions, is_default, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT INTO roles (id, team_id, name, color, position, permissions, is_default, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         params![
             role.id,
             role.team_id,
@@ -467,6 +480,7 @@ pub fn create_role(conn: &Connection, role: &Role) -> Result<(), rusqlite::Error
             role.permissions,
             role.is_default as i32,
             role.created_at,
+            updated,
         ],
     )?;
     Ok(())
@@ -477,7 +491,7 @@ pub fn get_roles_by_team(
     team_id: &str,
 ) -> Result<Vec<Role>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT id, team_id, name, color, position, permissions, is_default, created_at
+        "SELECT id, team_id, name, color, position, permissions, is_default, created_at, updated_at
          FROM roles WHERE team_id = ?1 ORDER BY position ASC",
     )?;
     let rows = stmt.query_map([team_id], |row| row_to_role(row))?;
@@ -486,7 +500,7 @@ pub fn get_roles_by_team(
 
 pub fn get_role_by_id(conn: &Connection, id: &str) -> Result<Option<Role>, rusqlite::Error> {
     conn.query_row(
-        "SELECT id, team_id, name, color, position, permissions, is_default, created_at FROM roles WHERE id = ?1",
+        "SELECT id, team_id, name, color, position, permissions, is_default, created_at, updated_at FROM roles WHERE id = ?1",
         [id],
         |row| row_to_role(row),
     )
@@ -495,8 +509,8 @@ pub fn get_role_by_id(conn: &Connection, id: &str) -> Result<Option<Role>, rusql
 
 pub fn update_role(conn: &Connection, role: &Role) -> Result<(), rusqlite::Error> {
     conn.execute(
-        "UPDATE roles SET name = ?1, color = ?2, position = ?3, permissions = ?4 WHERE id = ?5",
-        params![role.name, role.color, role.position, role.permissions, role.id],
+        "UPDATE roles SET name = ?1, color = ?2, position = ?3, permissions = ?4, updated_at = ?5 WHERE id = ?6",
+        params![role.name, role.color, role.position, role.permissions, now_str(), role.id],
     )?;
     Ok(())
 }
@@ -512,7 +526,7 @@ pub fn get_default_role_for_team(
     team_id: &str,
 ) -> Result<Option<Role>, rusqlite::Error> {
     conn.query_row(
-        "SELECT id, team_id, name, color, position, permissions, is_default, created_at FROM roles WHERE team_id = ?1 AND is_default = 1",
+        "SELECT id, team_id, name, color, position, permissions, is_default, created_at, updated_at FROM roles WHERE team_id = ?1 AND is_default = 1",
         [team_id],
         |row| row_to_role(row),
     )
@@ -529,7 +543,42 @@ fn row_to_role(row: &rusqlite::Row) -> Result<Role, rusqlite::Error> {
         permissions: row.get(5)?,
         is_default: row.get::<_, i32>(6)? != 0,
         created_at: row.get(7)?,
+        updated_at: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
     })
+}
+
+// ── Federation sync update queries ──────────────────────────────────────────
+
+pub fn update_channel_from_sync(conn: &Connection, ch: &Channel) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE channels SET name = ?1, topic = ?2, category = ?3, position = ?4, updated_at = ?5 WHERE id = ?6",
+        params![ch.name, ch.topic, ch.category, ch.position, ch.updated_at, ch.id],
+    )?;
+    Ok(())
+}
+
+pub fn update_role_from_sync(conn: &Connection, role: &Role) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE roles SET name = ?1, color = ?2, position = ?3, permissions = ?4, updated_at = ?5 WHERE id = ?6",
+        params![role.name, role.color, role.position, role.permissions, role.updated_at, role.id],
+    )?;
+    Ok(())
+}
+
+pub fn update_member_from_sync(conn: &Connection, member: &Member) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE members SET nickname = ?1, updated_at = ?2 WHERE id = ?3",
+        params![member.nickname, member.updated_at, member.id],
+    )?;
+    Ok(())
+}
+
+pub fn update_message_from_sync(conn: &Connection, msg: &Message) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE messages SET content = ?1, edited_at = ?2, deleted = ?3 WHERE id = ?4",
+        params![msg.content, msg.edited_at, msg.deleted as i32, msg.id],
+    )?;
+    Ok(())
 }
 
 // ── Member Role queries ─────────────────────────────────────────────────────
@@ -572,7 +621,7 @@ pub fn get_member_roles(
     member_id: &str,
 ) -> Result<Vec<Role>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT r.id, r.team_id, r.name, r.color, r.position, r.permissions, r.is_default, r.created_at
+        "SELECT r.id, r.team_id, r.name, r.color, r.position, r.permissions, r.is_default, r.created_at, r.updated_at
          FROM roles r
          JOIN member_roles mr ON mr.role_id = r.id
          WHERE mr.member_id = ?1
@@ -1043,8 +1092,9 @@ mod tests {
             team_id: team_id.to_string(),
             user_id: user_id.to_string(),
             nickname: String::new(),
-            joined_at: now,
+            joined_at: now.clone(),
             invited_by: user_id.to_string(),
+            updated_at: now,
         }
     }
 
@@ -1513,6 +1563,7 @@ mod tests {
             permissions: PERM_MANAGE_MESSAGES | PERM_MANAGE_MEMBERS,
             is_default: false,
             created_at: crate::db::now_str(),
+            updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
 
@@ -1534,12 +1585,12 @@ mod tests {
         let r1 = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Admin".into(),
             color: "#FF0000".into(), position: 2, permissions: PERM_ADMIN,
-            is_default: false, created_at: now.clone(),
+            is_default: false, created_at: now.clone(), updated_at: String::new(),
         };
         let r2 = Role {
             id: "r2".into(), team_id: "t1".into(), name: "Member".into(),
             color: "#00FF00".into(), position: 0, permissions: PERM_SEND_MESSAGES,
-            is_default: true, created_at: now,
+            is_default: true, created_at: now, updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &r1)).unwrap();
         db.with_conn(|c| create_role(c, &r2)).unwrap();
@@ -1561,7 +1612,7 @@ mod tests {
         let mut role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Mod".into(),
             color: "#000".into(), position: 0, permissions: 0,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
 
@@ -1585,7 +1636,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Temp".into(),
             color: "#000".into(), position: 0, permissions: 0,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
         db.with_conn(|c| delete_role(c, "r1")).unwrap();
@@ -1605,7 +1656,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "everyone".into(),
             color: "#000".into(), position: 0, permissions: PERM_SEND_MESSAGES,
-            is_default: true, created_at: crate::db::now_str(),
+            is_default: true, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
 
@@ -1630,12 +1681,12 @@ mod tests {
         let r1 = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Mod".into(),
             color: "#000".into(), position: 0, permissions: PERM_MANAGE_MESSAGES,
-            is_default: false, created_at: now.clone(),
+            is_default: false, created_at: now.clone(), updated_at: String::new(),
         };
         let r2 = Role {
             id: "r2".into(), team_id: "t1".into(), name: "Admin".into(),
             color: "#000".into(), position: 1, permissions: PERM_ADMIN,
-            is_default: false, created_at: now,
+            is_default: false, created_at: now, updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &r1)).unwrap();
         db.with_conn(|c| create_role(c, &r2)).unwrap();
@@ -1660,7 +1711,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Mod".into(),
             color: "#000".into(), position: 0, permissions: 0,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
 
@@ -1684,7 +1735,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Mod".into(),
             color: "#000".into(), position: 0, permissions: 0,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
 
@@ -1710,7 +1761,7 @@ mod tests {
             let role = Role {
                 id: format!("r{}", i), team_id: "t1".into(), name: format!("Role{}", i),
                 color: "#000".into(), position: i, permissions: 0,
-                is_default: false, created_at: now.clone(),
+                is_default: false, created_at: now.clone(), updated_at: String::new(),
             };
             db.with_conn(|c| create_role(c, &role)).unwrap();
             db.with_conn(|c| assign_role_to_member(c, "m1", &format!("r{}", i))).unwrap();
@@ -1767,7 +1818,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Mod".into(),
             color: "#000".into(), position: 0, permissions: PERM_MANAGE_MESSAGES,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
         db.with_conn(|c| assign_role_to_member(c, "m2", "r1")).unwrap();
@@ -1795,7 +1846,7 @@ mod tests {
         let role = Role {
             id: "r1".into(), team_id: "t1".into(), name: "Admin Role".into(),
             color: "#000".into(), position: 0, permissions: PERM_ADMIN,
-            is_default: false, created_at: crate::db::now_str(),
+            is_default: false, created_at: crate::db::now_str(), updated_at: String::new(),
         };
         db.with_conn(|c| create_role(c, &role)).unwrap();
         db.with_conn(|c| assign_role_to_member(c, "m2", "r1")).unwrap();

--- a/server-rs/src/federation/sync.rs
+++ b/server-rs/src/federation/sync.rs
@@ -147,7 +147,9 @@ impl SyncManager {
 
     /// Handle an incoming state sync response by merging the data into the local DB.
     ///
-    /// Uses "create if not exists" semantics — existing records are not overwritten.
+    /// Uses last-writer-wins conflict resolution: if a remote record has a newer
+    /// `updated_at` (or `edited_at` for messages), the local record is overwritten.
+    /// New records are inserted. The entire merge runs in a single transaction.
     pub async fn handle_state_sync_response(&self, data: StateSyncData) -> Result<(), String> {
         let db = self.db.clone();
 
@@ -158,60 +160,118 @@ impl SyncManager {
 
         tokio::task::spawn_blocking(move || {
             db.with_conn(|conn| {
-                // Merge channels.
-                for channel in &data.channels {
-                    let existing = db::get_channel_by_id(conn, &channel.id)?;
-                    if existing.is_none() {
-                        db::create_channel(conn, channel)?;
-                        tracing::debug!(
-                            channel_id = %channel.id,
-                            name = %channel.name,
-                            "synced channel from peer"
-                        );
+                conn.execute_batch("BEGIN")?;
+
+                let result = (|| {
+                    // Merge channels (last-writer-wins on updated_at).
+                    for channel in &data.channels {
+                        if let Some(existing) = db::get_channel_by_id(conn, &channel.id)? {
+                            if channel.updated_at > existing.updated_at {
+                                db::update_channel_from_sync(conn, channel)?;
+                                tracing::debug!(
+                                    channel_id = %channel.id,
+                                    name = %channel.name,
+                                    "updated channel from peer (newer)"
+                                );
+                            }
+                        } else {
+                            db::create_channel(conn, channel)?;
+                            tracing::debug!(
+                                channel_id = %channel.id,
+                                name = %channel.name,
+                                "synced channel from peer"
+                            );
+                        }
+                    }
+
+                    // Merge roles (last-writer-wins on updated_at).
+                    for role in &data.roles {
+                        if let Some(existing) = db::get_role_by_id(conn, &role.id)? {
+                            if role.updated_at > existing.updated_at {
+                                db::update_role_from_sync(conn, role)?;
+                                tracing::debug!(
+                                    role_id = %role.id,
+                                    name = %role.name,
+                                    "updated role from peer (newer)"
+                                );
+                            }
+                        } else {
+                            db::create_role(conn, role)?;
+                            tracing::debug!(
+                                role_id = %role.id,
+                                name = %role.name,
+                                "synced role from peer"
+                            );
+                        }
+                    }
+
+                    // Merge members (last-writer-wins on updated_at).
+                    for member in &data.members {
+                        if let Some(existing) =
+                            db::get_member_by_user_and_team(conn, &member.user_id, &member.team_id)?
+                        {
+                            if member.updated_at > existing.updated_at {
+                                db::update_member_from_sync(conn, member)?;
+                                tracing::debug!(
+                                    member_id = %member.id,
+                                    user_id = %member.user_id,
+                                    "updated member from peer (newer)"
+                                );
+                            }
+                        } else {
+                            db::create_member(conn, member)?;
+                            tracing::debug!(
+                                member_id = %member.id,
+                                user_id = %member.user_id,
+                                "synced member from peer"
+                            );
+                        }
+                    }
+
+                    // Merge messages (last-writer-wins on edited_at; handle soft-deletes).
+                    for message in &data.messages {
+                        if let Some(existing) = db::get_message_by_id(conn, &message.id)? {
+                            // Determine if the remote version is newer.
+                            let remote_ts = message.edited_at.as_deref().unwrap_or("");
+                            let local_ts = existing.edited_at.as_deref().unwrap_or("");
+                            let should_update = if message.deleted && !existing.deleted {
+                                // Remote deleted, local not — accept deletion if remote is newer or same.
+                                remote_ts >= local_ts
+                            } else {
+                                remote_ts > local_ts
+                            };
+                            if should_update {
+                                db::update_message_from_sync(conn, message)?;
+                                tracing::debug!(
+                                    message_id = %message.id,
+                                    channel_id = %message.channel_id,
+                                    deleted = message.deleted,
+                                    "updated message from peer (newer)"
+                                );
+                            }
+                        } else {
+                            db::create_message(conn, message)?;
+                            tracing::debug!(
+                                message_id = %message.id,
+                                channel_id = %message.channel_id,
+                                "synced message from peer"
+                            );
+                        }
+                    }
+
+                    Ok::<(), rusqlite::Error>(())
+                })();
+
+                match result {
+                    Ok(()) => {
+                        conn.execute_batch("COMMIT")?;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        Err(e)
                     }
                 }
-
-                // Merge roles.
-                for role in &data.roles {
-                    let existing = db::get_role_by_id(conn, &role.id)?;
-                    if existing.is_none() {
-                        db::create_role(conn, role)?;
-                        tracing::debug!(
-                            role_id = %role.id,
-                            name = %role.name,
-                            "synced role from peer"
-                        );
-                    }
-                }
-
-                // Merge members.
-                for member in &data.members {
-                    let existing =
-                        db::get_member_by_user_and_team(conn, &member.user_id, &member.team_id)?;
-                    if existing.is_none() {
-                        db::create_member(conn, member)?;
-                        tracing::debug!(
-                            member_id = %member.id,
-                            user_id = %member.user_id,
-                            "synced member from peer"
-                        );
-                    }
-                }
-
-                // Merge messages.
-                for message in &data.messages {
-                    let existing = db::get_message_by_id(conn, &message.id)?;
-                    if existing.is_none() {
-                        db::create_message(conn, message)?;
-                        tracing::debug!(
-                            message_id = %message.id,
-                            channel_id = %message.channel_id,
-                            "synced message from peer"
-                        );
-                    }
-                }
-
-                Ok(())
             })
         })
         .await
@@ -401,6 +461,7 @@ mod tests {
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: String::new(),
+                updated_at: now.clone(),
             }],
             roles: vec![db::Role {
                 id: "r1".into(),
@@ -411,6 +472,7 @@ mod tests {
                 permissions: 0,
                 is_default: true,
                 created_at: now.clone(),
+                updated_at: now.clone(),
             }],
         };
 
@@ -499,6 +561,7 @@ mod tests {
                 nickname: String::new(),
                 joined_at: now.clone(),
                 invited_by: String::new(),
+                updated_at: now.clone(),
             }],
             roles: vec![db::Role {
                 id: db::new_id(),
@@ -509,6 +572,7 @@ mod tests {
                 permissions: 0,
                 is_default: false,
                 created_at: now.clone(),
+                updated_at: now.clone(),
             }],
         };
 
@@ -644,5 +708,355 @@ mod tests {
         let transport = Arc::new(Transport::new());
         let mgr = SyncManager::new(db, transport, "my-node".into());
         assert_eq!(mgr.node_name, "my-node");
+    }
+
+    // ── Conflict resolution (last-writer-wins) tests ────────────────
+
+    /// Helper: create a team + user in the given database, returning (team_id, user_id).
+    fn setup_team_and_user(db: &Database) -> (String, String) {
+        let now = db::now_str();
+        let team_id = db::new_id();
+        let user_id = db::new_id();
+        db.with_conn(|conn| {
+            db::create_user(conn, &db::User {
+                id: user_id.clone(),
+                username: format!("user-{}", &user_id[..8]),
+                display_name: "Test User".into(),
+                public_key: user_id.as_bytes().to_vec(),
+                avatar_url: String::new(),
+                status_text: String::new(),
+                status_type: "online".into(),
+                is_admin: false,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+            })?;
+            db::create_team(conn, &db::Team {
+                id: team_id.clone(),
+                name: "Test Team".into(),
+                description: String::new(),
+                icon_url: String::new(),
+                created_by: user_id.clone(),
+                max_file_size: 25 * 1024 * 1024,
+                allow_member_invites: true,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+            })
+        })
+        .unwrap();
+        (team_id, user_id)
+    }
+
+    #[tokio::test]
+    async fn test_sync_merge_updates_existing_channel_when_newer() {
+        let db = test_db();
+        let transport = Arc::new(Transport::new());
+        let mgr = SyncManager::new(db.clone(), transport, "test-node".into());
+        let (team_id, user_id) = setup_team_and_user(&db);
+
+        let channel_id = db::new_id();
+        let old_time = "2025-01-01 00:00:00".to_string();
+        let new_time = "2025-06-01 00:00:00".to_string();
+
+        // Insert local channel with old timestamp.
+        db.with_conn(|conn| {
+            db::create_channel(conn, &db::Channel {
+                id: channel_id.clone(),
+                team_id: team_id.clone(),
+                name: "old-name".into(),
+                topic: "old-topic".into(),
+                channel_type: "text".into(),
+                position: 0,
+                category: String::new(),
+                created_by: user_id.clone(),
+                created_at: old_time.clone(),
+                updated_at: old_time.clone(),
+            })
+        })
+        .unwrap();
+
+        // Sync a newer version from a peer.
+        let sync_data = StateSyncData {
+            channels: vec![db::Channel {
+                id: channel_id.clone(),
+                team_id: team_id.clone(),
+                name: "new-name".into(),
+                topic: "new-topic".into(),
+                channel_type: "text".into(),
+                position: 1,
+                category: "announcements".into(),
+                created_by: user_id.clone(),
+                created_at: old_time.clone(),
+                updated_at: new_time.clone(),
+            }],
+            messages: Vec::new(),
+            members: Vec::new(),
+            roles: Vec::new(),
+        };
+
+        mgr.handle_state_sync_response(sync_data).await.unwrap();
+
+        // Verify the channel was updated.
+        db.with_conn(|conn| {
+            let ch = db::get_channel_by_id(conn, &channel_id)?.unwrap();
+            assert_eq!(ch.name, "new-name");
+            assert_eq!(ch.topic, "new-topic");
+            assert_eq!(ch.position, 1);
+            assert_eq!(ch.category, "announcements");
+            assert_eq!(ch.updated_at, new_time);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sync_merge_keeps_local_channel_when_newer() {
+        let db = test_db();
+        let transport = Arc::new(Transport::new());
+        let mgr = SyncManager::new(db.clone(), transport, "test-node".into());
+        let (team_id, user_id) = setup_team_and_user(&db);
+
+        let channel_id = db::new_id();
+        let old_time = "2025-01-01 00:00:00".to_string();
+        let new_time = "2025-06-01 00:00:00".to_string();
+
+        // Insert local channel with NEWER timestamp.
+        db.with_conn(|conn| {
+            db::create_channel(conn, &db::Channel {
+                id: channel_id.clone(),
+                team_id: team_id.clone(),
+                name: "local-name".into(),
+                topic: "local-topic".into(),
+                channel_type: "text".into(),
+                position: 0,
+                category: String::new(),
+                created_by: user_id.clone(),
+                created_at: old_time.clone(),
+                updated_at: new_time.clone(),
+            })
+        })
+        .unwrap();
+
+        // Sync an older version from a peer.
+        let sync_data = StateSyncData {
+            channels: vec![db::Channel {
+                id: channel_id.clone(),
+                team_id: team_id.clone(),
+                name: "remote-name".into(),
+                topic: "remote-topic".into(),
+                channel_type: "text".into(),
+                position: 5,
+                category: String::new(),
+                created_by: user_id.clone(),
+                created_at: old_time.clone(),
+                updated_at: old_time.clone(),
+            }],
+            messages: Vec::new(),
+            members: Vec::new(),
+            roles: Vec::new(),
+        };
+
+        mgr.handle_state_sync_response(sync_data).await.unwrap();
+
+        // Verify local channel was NOT overwritten.
+        db.with_conn(|conn| {
+            let ch = db::get_channel_by_id(conn, &channel_id)?.unwrap();
+            assert_eq!(ch.name, "local-name");
+            assert_eq!(ch.topic, "local-topic");
+            assert_eq!(ch.position, 0);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sync_merge_updates_existing_role_when_newer() {
+        let db = test_db();
+        let transport = Arc::new(Transport::new());
+        let mgr = SyncManager::new(db.clone(), transport, "test-node".into());
+        let (team_id, _user_id) = setup_team_and_user(&db);
+
+        let role_id = db::new_id();
+        let old_time = "2025-01-01 00:00:00".to_string();
+        let new_time = "2025-06-01 00:00:00".to_string();
+
+        // Insert local role with old timestamp.
+        db.with_conn(|conn| {
+            db::create_role(conn, &db::Role {
+                id: role_id.clone(),
+                team_id: team_id.clone(),
+                name: "old-role".into(),
+                color: "#000000".into(),
+                position: 0,
+                permissions: 0,
+                is_default: false,
+                created_at: old_time.clone(),
+                updated_at: old_time.clone(),
+            })
+        })
+        .unwrap();
+
+        // Sync a newer version.
+        let sync_data = StateSyncData {
+            channels: Vec::new(),
+            messages: Vec::new(),
+            members: Vec::new(),
+            roles: vec![db::Role {
+                id: role_id.clone(),
+                team_id: team_id.clone(),
+                name: "new-role".into(),
+                color: "#FF0000".into(),
+                position: 5,
+                permissions: 255,
+                is_default: false,
+                created_at: old_time.clone(),
+                updated_at: new_time.clone(),
+            }],
+        };
+
+        mgr.handle_state_sync_response(sync_data).await.unwrap();
+
+        // Verify role was updated.
+        db.with_conn(|conn| {
+            let role = db::get_role_by_id(conn, &role_id)?.unwrap();
+            assert_eq!(role.name, "new-role");
+            assert_eq!(role.color, "#FF0000");
+            assert_eq!(role.position, 5);
+            assert_eq!(role.permissions, 255);
+            assert_eq!(role.updated_at, new_time);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sync_merge_in_transaction() {
+        let db = test_db();
+        let transport = Arc::new(Transport::new());
+        let mgr = SyncManager::new(db.clone(), transport, "test-node".into());
+        let (team_id, user_id) = setup_team_and_user(&db);
+
+        let ch1_id = db::new_id();
+        let ch2_id = db::new_id();
+        let now = db::now_str();
+
+        // Sync two channels at once — both should appear atomically.
+        let sync_data = StateSyncData {
+            channels: vec![
+                db::Channel {
+                    id: ch1_id.clone(),
+                    team_id: team_id.clone(),
+                    name: "channel-1".into(),
+                    topic: String::new(),
+                    channel_type: "text".into(),
+                    position: 0,
+                    category: String::new(),
+                    created_by: user_id.clone(),
+                    created_at: now.clone(),
+                    updated_at: now.clone(),
+                },
+                db::Channel {
+                    id: ch2_id.clone(),
+                    team_id: team_id.clone(),
+                    name: "channel-2".into(),
+                    topic: String::new(),
+                    channel_type: "text".into(),
+                    position: 1,
+                    category: String::new(),
+                    created_by: user_id.clone(),
+                    created_at: now.clone(),
+                    updated_at: now.clone(),
+                },
+            ],
+            messages: Vec::new(),
+            members: Vec::new(),
+            roles: Vec::new(),
+        };
+
+        mgr.handle_state_sync_response(sync_data).await.unwrap();
+
+        // Both channels should exist.
+        db.with_conn(|conn| {
+            let channels = db::get_channels_by_team(conn, &team_id)?;
+            assert_eq!(channels.len(), 2);
+            let names: Vec<&str> = channels.iter().map(|c| c.name.as_str()).collect();
+            assert!(names.contains(&"channel-1"));
+            assert!(names.contains(&"channel-2"));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sync_merge_handles_deleted_messages() {
+        let db = test_db();
+        let transport = Arc::new(Transport::new());
+        let mgr = SyncManager::new(db.clone(), transport, "test-node".into());
+        let (team_id, user_id) = setup_team_and_user(&db);
+
+        let channel_id = db::new_id();
+        let message_id = db::new_id();
+        let now = "2025-01-01 00:00:00".to_string();
+        let edit_time = "2025-06-01 00:00:00".to_string();
+
+        // Create channel and message locally.
+        db.with_conn(|conn| {
+            db::create_channel(conn, &db::Channel {
+                id: channel_id.clone(),
+                team_id: team_id.clone(),
+                name: "general".into(),
+                topic: String::new(),
+                channel_type: "text".into(),
+                position: 0,
+                category: String::new(),
+                created_by: user_id.clone(),
+                created_at: now.clone(),
+                updated_at: now.clone(),
+            })?;
+            db::create_message(conn, &db::Message {
+                id: message_id.clone(),
+                channel_id: channel_id.clone(),
+                dm_channel_id: String::new(),
+                author_id: user_id.clone(),
+                content: "original content".into(),
+                msg_type: "text".into(),
+                thread_id: String::new(),
+                edited_at: None,
+                deleted: false,
+                lamport_ts: 1,
+                created_at: now.clone(),
+            })
+        })
+        .unwrap();
+
+        // Sync a deleted version of the same message from a peer.
+        let sync_data = StateSyncData {
+            channels: Vec::new(),
+            messages: vec![db::Message {
+                id: message_id.clone(),
+                channel_id: channel_id.clone(),
+                dm_channel_id: String::new(),
+                author_id: user_id.clone(),
+                content: String::new(),
+                msg_type: "text".into(),
+                thread_id: String::new(),
+                edited_at: Some(edit_time.clone()),
+                deleted: true,
+                lamport_ts: 1,
+                created_at: now.clone(),
+            }],
+            members: Vec::new(),
+            roles: Vec::new(),
+        };
+
+        mgr.handle_state_sync_response(sync_data).await.unwrap();
+
+        // Verify message is now soft-deleted.
+        db.with_conn(|conn| {
+            let msg = db::get_message_by_id(conn, &message_id)?.unwrap();
+            assert!(msg.deleted);
+            assert!(msg.content.is_empty());
+            Ok(())
+        })
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Replace "create if not exists" federation sync with last-writer-wins conflict resolution.

**Before:** If two nodes modify the same channel during a network partition, only the first sync wins. Updates never propagate — nodes stay permanently divergent.

**After:** Each entity has an `updated_at` timestamp. During sync, if the remote record is newer than the local one, the local record is updated. The entire merge runs in a transaction for atomicity.

### Changes
- **Migration 006:** Add `updated_at` column to `roles` and `members` tables
- **Sync merge strategy:** Last-writer-wins using `updated_at` (channels, roles, members) and `edited_at` (messages)
- **Soft delete propagation:** Deleted messages sync between nodes
- **Transaction wrapping:** Entire merge in `BEGIN`/`COMMIT` with `ROLLBACK` on error
- **4 new sync-specific update queries**
- **5 new tests:** LWW merge, local-wins, role merge, transaction atomicity, deleted message propagation

## Test plan

- [x] `cargo check` — 0 errors, 0 warnings
- [x] `cargo test` — 294/294 pass (5 new)

Addresses architectural issue #6 from the code review.