### PR TITLE
fix: make Claude Code review non-blocking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Non-blocking — fails gracefully if CLAUDE_CODE_OAUTH_TOKEN is not set
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The claude-review workflow fails with 401 when CLAUDE_CODE_OAUTH_TOKEN is not set. Added continue-on-error so it doesn't block PRs. Once the token is configured, the review will still run — it just won't block merges on failure.