### PR TITLE
chore: update all 15 outdated Rust crates to latest versions

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-nnnoiseless = "0.1"
-rand = "0.8"
+nnnoiseless = "0.5"
+rand = "0.9"
 base64 = "0.22"
 # auth_server dependencies
 tiny_http = "0.12.0"
 open = "5.3.3"
-ureq = { version = "2", features = ["json"] }
+ureq = { version = "3", features = ["json"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/client/src-tauri/src/auth_server.rs
+++ b/client/src-tauri/src/auth_server.rs
@@ -50,7 +50,7 @@ pub struct LoginResult {
 }
 
 fn generate_nonce() -> String {
-    let bytes: [u8; 32] = rand::thread_rng().gen();
+    let bytes: [u8; 32] = rand::rng().gen();
     base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes)
 }
 

--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 [dependencies]
 # Web framework
 axum = { version = "0.8", features = ["ws", "multipart"] }
-axum-extra = { version = "0.10", features = ["typed-header"] }
+axum-extra = { version = "0.12", features = ["typed-header"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "set-header", "limit", "fs"] }
 
 # Database
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher"] }
+rusqlite = { version = "0.39", features = ["bundled-sqlcipher"] }
 
 # Auth & Crypto
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
-rand = "0.8"
+rand = "0.9"
 hmac = "0.12"
 sha1 = "0.10"
 sha2 = "0.10"
@@ -43,7 +43,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Rate limiting
-governor = "0.8"
+governor = "0.10"
 
 # TLS
 tokio-rustls = "0.26"
@@ -54,23 +54,23 @@ rustls-pemfile = "2"
 rust-embed = "8"
 
 # WebRTC
-webrtc = "0.11"
+webrtc = "0.17"
 async-trait = "0.1"
 
 # OpenTelemetry
-opentelemetry = "0.27"
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "trace", "metrics", "logs", "internal-logs"] }
-tracing-opentelemetry = "0.28"
+opentelemetry = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-proto", "trace", "metrics", "logs", "internal-logs"] }
+tracing-opentelemetry = "0.32"
 
 # Regex (route sanitisation)
 regex = "1"
 
 # Federation transport
-tokio-tungstenite = { version = "0.24", features = ["connect"] }
+tokio-tungstenite = { version = "0.29", features = ["connect"] }
 
 # HTTP client (for TURN API calls)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/server-rs/src/api/mod.rs
+++ b/server-rs/src/api/mod.rs
@@ -318,6 +318,7 @@ mod tests {
     use crate::db::{self, Database};
     use crate::presence::PresenceManager;
     use ed25519_dalek::{Signer, SigningKey};
+    use rand::RngCore;
     use base64::Engine;
     use tower::ServiceExt;
 
@@ -598,7 +599,11 @@ mod tests {
         let (state, _tmp) = test_app_state();
         let app = test_router(state);
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let pk = signing_key.verifying_key();
         let pk_b64 = base64::engine::general_purpose::STANDARD.encode(pk.as_bytes());
 
@@ -675,7 +680,11 @@ mod tests {
         let auth = state.auth.clone();
         let app = test_router(state);
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let pk = signing_key.verifying_key();
         let pk_b64 = base64::engine::general_purpose::STANDARD.encode(pk.as_bytes());
 
@@ -711,7 +720,11 @@ mod tests {
         let auth = state.auth.clone();
         let app = test_router(state.clone());
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let pk = signing_key.verifying_key();
         let pk_b64 = base64::engine::general_purpose::STANDARD.encode(pk.as_bytes());
 
@@ -757,7 +770,11 @@ mod tests {
         let auth = state.auth.clone();
         let app = test_router(state);
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let pk = signing_key.verifying_key();
         let pk_b64 = base64::engine::general_purpose::STANDARD.encode(pk.as_bytes());
 

--- a/server-rs/src/auth.rs
+++ b/server-rs/src/auth.rs
@@ -49,7 +49,7 @@ fn derive_jwt_secret(db_passphrase: &str) -> Vec<u8> {
     if db_passphrase.is_empty() {
         // Insecure mode: ephemeral random secret (lost on restart)
         let mut raw = vec![0u8; 32];
-        rand::thread_rng().fill_bytes(&mut raw);
+        rand::rng().fill_bytes(&mut raw);
         return raw;
     }
     // Derive from passphrase using HKDF-SHA256
@@ -92,10 +92,10 @@ impl AuthService {
 
     pub fn generate_challenge(&self) -> Result<(Vec<u8>, String), AppError> {
         let mut nonce = vec![0u8; 32];
-        rand::thread_rng().fill_bytes(&mut nonce);
+        rand::rng().fill_bytes(&mut nonce);
 
         let mut id_bytes = vec![0u8; 16];
-        rand::thread_rng().fill_bytes(&mut id_bytes);
+        rand::rng().fill_bytes(&mut id_bytes);
         let challenge_id = hex::encode(&id_bytes);
 
         self.challenges.write().unwrap().insert(
@@ -234,7 +234,7 @@ impl AuthService {
 
     pub fn generate_bootstrap_token(&self) -> Result<String, AppError> {
         let mut bytes = vec![0u8; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
+        rand::rng().fill_bytes(&mut bytes);
         let token = hex::encode(&bytes);
         self.db
             .with_conn(|conn| db::create_bootstrap_token(conn, &token))
@@ -244,7 +244,7 @@ impl AuthService {
 
     pub fn generate_invite_token(&self) -> String {
         let mut bytes = vec![0u8; 16];
-        rand::thread_rng().fill_bytes(&mut bytes);
+        rand::rng().fill_bytes(&mut bytes);
         hex::encode(&bytes)
     }
 
@@ -298,7 +298,7 @@ mod tests {
     fn test_auth_service() -> AuthService {
         let db = test_db();
         let mut raw = vec![0u8; 32];
-        rand::thread_rng().fill_bytes(&mut raw);
+        rand::rng().fill_bytes(&mut raw);
         AuthService {
             db,
             jwt_secret: raw,
@@ -346,7 +346,11 @@ mod tests {
         let (nonce, challenge_id) = auth.generate_challenge().unwrap();
 
         // Generate a keypair and sign the nonce
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let verifying_key = signing_key.verifying_key();
         let signature = signing_key.sign(&nonce);
 
@@ -365,7 +369,11 @@ mod tests {
         let auth = test_auth_service();
         let (_nonce, challenge_id) = auth.generate_challenge().unwrap();
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let verifying_key = signing_key.verifying_key();
         // Sign wrong data
         let wrong_sig = signing_key.sign(b"wrong data");
@@ -384,7 +392,11 @@ mod tests {
     fn test_verify_challenge_nonexistent_id() {
         let auth = test_auth_service();
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let verifying_key = signing_key.verifying_key();
         let sig = signing_key.sign(b"data");
 
@@ -401,7 +413,11 @@ mod tests {
         let auth = test_auth_service();
         let (nonce, challenge_id) = auth.generate_challenge().unwrap();
 
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let signing_key = {
+                let mut key_bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut key_bytes);
+                SigningKey::from_bytes(&key_bytes)
+            };
         let verifying_key = signing_key.verifying_key();
         let signature = signing_key.sign(&nonce);
 
@@ -493,15 +509,7 @@ mod tests {
         let token = auth.generate_jwt("user-1").unwrap();
 
         // Decode without validation to inspect claims
-        let mut validation = jsonwebtoken::Validation::default();
-        validation.insecure_disable_signature_validation();
-        validation.validate_exp = false;
-        let data = jsonwebtoken::decode::<Claims>(
-            &token,
-            &jsonwebtoken::DecodingKey::from_secret(&[]),
-            &validation,
-        )
-        .unwrap();
+        let data = jsonwebtoken::dangerous::insecure_decode::<Claims>(&token).unwrap();
 
         // Expiry should be 1 hour from iat
         let diff = data.claims.exp - data.claims.iat;
@@ -524,15 +532,7 @@ mod tests {
         let auth = test_auth_service();
         let refresh = auth.generate_refresh_token("user-1").unwrap();
 
-        let mut validation = jsonwebtoken::Validation::default();
-        validation.insecure_disable_signature_validation();
-        validation.validate_exp = false;
-        let data = jsonwebtoken::decode::<RefreshClaims>(
-            &refresh,
-            &jsonwebtoken::DecodingKey::from_secret(&[]),
-            &validation,
-        )
-        .unwrap();
+        let data = jsonwebtoken::dangerous::insecure_decode::<RefreshClaims>(&refresh).unwrap();
 
         let diff = data.claims.exp - data.claims.iat;
         assert_eq!(diff, 7 * 24 * 3600);

--- a/server-rs/src/federation/join.rs
+++ b/server-rs/src/federation/join.rs
@@ -51,7 +51,7 @@ impl JoinManager {
         let secret = if join_secret.is_empty() {
             // Generate a random 32-byte secret.
             let mut bytes = vec![0u8; 32];
-            rand::thread_rng().fill_bytes(&mut bytes);
+            rand::rng().fill_bytes(&mut bytes);
             bytes
         } else {
             join_secret.as_bytes().to_vec()

--- a/server-rs/src/observability/mod.rs
+++ b/server-rs/src/observability/mod.rs
@@ -21,7 +21,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     metrics::{PeriodicReader, SdkMeterProvider},
-    trace::TracerProvider,
+    trace::SdkTracerProvider,
     Resource,
 };
 use std::sync::Arc;
@@ -55,7 +55,7 @@ pub fn init_logging(config: &Config) {
 /// noops — zero overhead.
 #[allow(dead_code)]
 pub struct OtelProviders {
-    pub tracer_provider: Option<TracerProvider>,
+    pub tracer_provider: Option<SdkTracerProvider>,
     pub meter_provider: Option<SdkMeterProvider>,
 }
 
@@ -99,10 +99,12 @@ pub fn init_otel(config: &Config) -> Result<OtelProviders, Box<dyn std::error::E
         config.otel_service_name.clone()
     };
 
-    let resource = Resource::new(vec![
-        KeyValue::new("service.name", service_name.clone()),
-        KeyValue::new("service.version", env!("CARGO_PKG_VERSION").to_string()),
-    ]);
+    let resource = Resource::builder()
+        .with_attributes(vec![
+            KeyValue::new("service.name", service_name.clone()),
+            KeyValue::new("service.version", env!("CARGO_PKG_VERSION").to_string()),
+        ])
+        .build();
 
     let endpoint = if !config.otel_http_endpoint.is_empty() {
         config.otel_http_endpoint.clone()
@@ -136,8 +138,8 @@ pub fn init_otel(config: &Config) -> Result<OtelProviders, Box<dyn std::error::E
 
     let trace_exporter = trace_builder.build()?;
 
-    let tracer_provider = TracerProvider::builder()
-        .with_batch_exporter(trace_exporter, opentelemetry_sdk::runtime::Tokio)
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(trace_exporter)
         .with_resource(resource.clone())
         .build();
 
@@ -159,7 +161,7 @@ pub fn init_otel(config: &Config) -> Result<OtelProviders, Box<dyn std::error::E
 
     let metric_exporter = metric_builder.build()?;
 
-    let reader = PeriodicReader::builder(metric_exporter, opentelemetry_sdk::runtime::Tokio)
+    let reader = PeriodicReader::builder(metric_exporter)
         .build();
 
     let meter_provider = SdkMeterProvider::builder()


### PR DESCRIPTION
## Summary

Update all 15 outdated Rust crates across server and Tauri to their latest versions.

| Crate | From | To | Notes |
|---|---|---|---|
| jsonwebtoken | 9 | 10 | New Header/Validation API |
| rusqlite | 0.32 | 0.39 | |
| webrtc | 0.11 | 0.17 | SFU still works |
| axum-extra | 0.10 | 0.12 | |
| tokio-tungstenite | 0.24 | 0.29 | |
| reqwest | 0.12 | 0.13 | |
| governor | 0.8 | 0.10 | |
| rand | 0.8 | 0.9 | 0.10 blocked by ed25519-dalek 2.x |
| opentelemetry | 0.27 | 0.31 | TracerProvider → SdkTracerProvider |
| opentelemetry-otlp | 0.27 | 0.31 | |
| opentelemetry_sdk | 0.27 | 0.31 | Resource builder API |
| tracing-opentelemetry | 0.28 | 0.32 | |
| nnnoiseless | 0.1 | 0.5 | Tauri |
| rand (Tauri) | 0.8 | 0.9 | Tauri |
| ureq | 2 | 3 | Tauri |

## Test plan

- [x] `cargo test` — 305/305 pass
- [x] `cargo check` (Tauri) — clean
- [x] `vitest run` — 1,599/1,599 pass