### PR TITLE
fix: suppress JS rules on vendored rnnoise files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,9 @@ sonar.coverage.exclusions=**/*.test.{ts,tsx},client/src/test/**
 
 sonar.exclusions=client/public/**,**/rnnoise/**,docs/**
 
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:*
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/rnnoise/**,**/public/noise-suppressor-worklet.js
 sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S7781
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/telemetry.ts
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S4123


### PR DESCRIPTION
## Summary
SonarCloud Automatic Analysis ignores `sonar.exclusions` for files outside `sonar.sources`. The vendored `rnnoise.js` (WASM-generated) keeps triggering 2 reliability bugs despite being excluded.

This adds `sonar.issue.ignore.multicriteria` to suppress all `javascript:*` rules on `**/rnnoise/**` and the noise suppressor worklet.

This is the last bug blocking the A reliability rating.

## Test plan
- [x] No code changes — config only
- [ ] SonarQube rescan shows 0 bugs


🤖 Generated with [Claude Code](https://claude.com/claude-code)