### PR TITLE
feat: add SonarCloud CI scanner for Rust + TypeScript

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Create dist placeholder for rust-embed
         run: mkdir -p server-rs/dist && touch server-rs/dist/index.html
 
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Run Rust tests with coverage
+        working-directory: server-rs
+        run: cargo tarpaulin --out lcov --output-dir . -- --test-threads=1
+
       - name: Generate Clippy report
         working-directory: server-rs
         run: cargo clippy --message-format=json > clippy-report.json 2>&1 || true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.tests=client/src
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 
 sonar.javascript.lcov.reportPaths=client/coverage/lcov.info
+sonar.rust.lcov.reportPaths=server-rs/lcov.info
 sonar.coverage.exclusions=**/*.test.{ts,tsx},client/src/test/**
 sonar.cpd.exclusions=**/*.test.{ts,tsx},**/test/**,**/mock*
 


### PR DESCRIPTION
## Summary
Switch from Automatic Analysis to CI-based SonarCloud scanning to enable Rust code analysis.

### What this adds
- New `sonarcloud.yml` workflow: runs client tests (coverage), generates Clippy JSON report, runs SonarCloud scan
- Rust clippy report path in `sonar-project.properties`

### Setup required before merging
1. **Disable Automatic Analysis** in SonarCloud: Project Settings → Analysis Method → toggle off
2. **Add `SONAR_TOKEN`** secret in GitHub repo settings (get from SonarCloud → Project Settings → Analysis Method)

### After merge
SonarCloud will analyze both TypeScript and Rust code on every push/PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)