### PR TITLE
fix: include all 4 server binaries in nightly release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,14 +203,15 @@ jobs:
         with:
           path: artifacts/
           pattern: dilla-*
-          merge-multiple: true
 
       - name: Flatten and rename artifacts
         run: |
           mkdir -p release
           for dir in artifacts/dilla-server-*/; do
             name=$(basename "$dir")
-            cp "$dir"dilla-server "release/$name" 2>/dev/null || true
+            if [ -f "$dir/dilla-server" ]; then
+              cp "$dir/dilla-server" "release/$name"
+            fi
           done
           find artifacts -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.deb" \) -exec cp {} release/ \;
 


### PR DESCRIPTION
## Summary
The nightly release only included linux-amd64 because `merge-multiple: true` caused all 4 `dilla-server` binaries to overwrite each other.

Fix: download artifacts without merging, then rename each from `dilla-server` to `dilla-server-{platform}`.

### Expected nightly assets after merge
- `dilla-server-linux-amd64`
- `dilla-server-linux-arm64`
- `dilla-server-darwin-amd64`
- `dilla-server-darwin-arm64`
- Desktop apps + SHA256SUMS.txt


🤖 Generated with [Claude Code](https://claude.com/claude-code)