### PR TITLE
feat: add Windows server + desktop builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
         if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
 
+      - name: Install OpenSSL (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          vcpkg install openssl:x64-windows-static-md
+          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: client-dist


### PR DESCRIPTION
## Summary
Add Windows builds to CI and nightly release.

### New build targets
| Artifact | Platform | Runner |
|----------|----------|--------|
| `dilla-server-windows-amd64.exe` | x86_64-pc-windows-msvc | windows-latest |
| `Dilla_*.msi` | Windows installer | windows-latest |
| `Dilla_*.exe` | Windows portable | windows-latest |

### Full nightly release after merge
- Server: linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, **windows-amd64**
- Desktop: AppImage, deb, dmg, **msi, exe**


🤖 Generated with [Claude Code](https://claude.com/claude-code)