### PR TITLE
fix: security audit round 2 — voice key downgrade, security headers, chain advance limit

### DIFF
--- a/client/src/components/DMView/DMView.tsx
+++ b/client/src/components/DMView/DMView.tsx
@@ -84,7 +84,8 @@ export default function DMView({ dm, currentUserId, showMembers = false }: Reado
       const cached = await getCachedMessage(messageId);
       if (cached !== null) return cached;
 
-      if (!derivedKey || !activeTeamId) return content;
+      if (!derivedKey || !activeTeamId)
+        return '\u{1F512} *Encrypted message \u2014 unlock your identity to read*';
       try {
         const plaintext = await cryptoService.decryptDM(activeTeamId, senderId, content, dm.id, derivedKey);
         await cacheMessage(messageId, dm.id, plaintext);

--- a/client/src/pages/ChannelView.tsx
+++ b/client/src/pages/ChannelView.tsx
@@ -42,7 +42,7 @@ async function tryDecrypt(
 
   // Strip legacy dev prefix from old messages
   const clean = content.startsWith(DEV_PREFIX) ? content.slice(DEV_PREFIX.length) : content;
-  if (!derivedKey) return clean;
+  if (!derivedKey) return '\u{1F512} *Encrypted message \u2014 unlock your identity to read*';
   try {
     // Use decryptChannel which ensures the channel session is initialized
     const userId = getIdentityKeys().publicKeyBytes;

--- a/client/src/services/crypto/groupSession.ts
+++ b/client/src/services/crypto/groupSession.ts
@@ -144,6 +144,10 @@ export class GroupSession {
     if (!valid) throw new Error('Group message signature verification failed');
 
     // Advance chain to correct message number
+    const MAX_CHAIN_ADVANCE = 2000;
+    if (message.message_number - state.messageNumber > MAX_CHAIN_ADVANCE) {
+      throw new Error('Message gap too large — possible corruption or attack');
+    }
     while (state.messageNumber < message.message_number) {
       const [nextChain] = await kdfChain(state.chainKey);
       state.chainKey = nextChain;

--- a/client/src/services/cryptoCore.test.ts
+++ b/client/src/services/cryptoCore.test.ts
@@ -536,6 +536,19 @@ describe('GroupSession key rotation', () => {
     // Charlie can NOT decrypt with old key
     await expect(charlie.decrypt(msg)).rejects.toThrow();
   });
+
+  it('rejects message with gap larger than MAX_CHAIN_ADVANCE', async () => {
+    const alice = await GroupSession.create('ch1', 'alice');
+    const bob = await GroupSession.create('ch1', 'bob');
+
+    bob.processDistribution(alice.createDistributionMessage());
+
+    const msg = await alice.encrypt(encoder.encode('normal'));
+    // Tamper with message_number to be way beyond what bob expects
+    msg.message_number = 3000;
+
+    await expect(bob.decrypt(msg)).rejects.toThrow('Message gap too large');
+  });
 });
 
 // ─── Safety Numbers ──────────────────────────────────────────────────────────

--- a/client/src/services/webrtc/voiceEncryption.ts
+++ b/client/src/services/webrtc/voiceEncryption.ts
@@ -90,19 +90,18 @@ export class VoiceEncryptionManager {
   ): Promise<void> {
     const derivedKey = useAuthStore.getState().derivedKey;
 
+    if (!derivedKey || !teamId || !channelId) {
+      console.warn('[Voice] Missing derivedKey/teamId/channelId — rejecting voice key from', senderId);
+      return;
+    }
+
     let keyBase64: string;
     try {
-      if (derivedKey && teamId && channelId) {
-        // Decrypt the voice key using the sender's Signal Protocol session
-        keyBase64 = await cryptoService.decryptDM(teamId, senderId, encryptedKey, channelId, derivedKey);
-      } else {
-        // Fallback: assume unencrypted (backward compat with old clients)
-        keyBase64 = encryptedKey;
-      }
+      // Decrypt the voice key using the sender's Signal Protocol session
+      keyBase64 = await cryptoService.decryptDM(teamId, senderId, encryptedKey, channelId, derivedKey);
     } catch (err) {
-      console.warn('[Voice] Failed to decrypt voice key from', senderId, err);
-      // Try treating as unencrypted for backward compatibility
-      keyBase64 = encryptedKey;
+      console.error('[Voice] Failed to decrypt voice key from', senderId, err);
+      return;
     }
 
     const rawKey = new Uint8Array(

--- a/server-rs/src/api/mod.rs
+++ b/server-rs/src/api/mod.rs
@@ -23,12 +23,14 @@ use crate::presence::PresenceManager;
 use crate::ws::Hub;
 use axum::{
     extract::Extension,
+    http::HeaderValue,
     middleware,
     routing::{delete, get, patch, post, put},
     Json, Router,
 };
 use std::sync::{Arc, OnceLock};
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::set_header::SetResponseHeaderLayer;
 
 pub static VERSION: OnceLock<String> = OnceLock::new();
 
@@ -44,8 +46,16 @@ pub struct AppState {
 
 #[cfg(not(tarpaulin_include))]
 pub fn create_router(state: AppState) -> Router {
+    // TODO(NEW-10): trusted_proxies config should be used for X-Forwarded-For
+    // resolution to correctly identify client IPs behind reverse proxies.
+
     let cors = if state.config.allowed_origins.is_empty() {
-        CorsLayer::very_permissive()
+        if state.config.insecure {
+            CorsLayer::very_permissive()
+        } else {
+            // Restrictive default: same-origin only when no origins configured.
+            CorsLayer::new()
+        }
     } else {
         let origins: Vec<_> = state
             .config
@@ -242,12 +252,28 @@ pub fn create_router(state: AppState) -> Router {
     let ws_route = Router::new()
         .route("/ws", get(ws_handler));
 
+    // TODO(NEW-07): Add rate limiting to public auth routes using governor/tower-governor
+    // once tower-governor is added as a dependency. Target: 10 requests/minute per IP
+    // on /api/v1/auth/* endpoints.
+
     Router::new()
         .merge(public)
         .merge(protected)
         .merge(ws_route)
         .layer(Extension(state.auth.clone()))
         .layer(cors)
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
         .fallback_service(crate::webapp::webapp_fallback())
         .with_state(state)
 }

--- a/server-rs/src/api/uploads.rs
+++ b/server-rs/src/api/uploads.rs
@@ -73,6 +73,11 @@ pub async fn upload(
         )));
     }
 
+    // Validate team_id to prevent path traversal.
+    if tid.contains("..") || tid.contains('/') || tid.contains('\\') {
+        return Err(AppError::BadRequest("invalid team id".into()));
+    }
+
     // Write file to disk.
     let attachment_id = db::new_id();
     let upload_dir = PathBuf::from(&state.config.upload_dir).join(&tid);

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -119,11 +119,11 @@ fn check_first_start(database: &Database, auth_svc: &AuthService, port: u16) {
         Ok(false) => {
             match auth_svc.generate_bootstrap_token() {
                 Ok(token) => {
-                    println!();
-                    println!("  *** First-time setup ***");
-                    println!("  Open http://<your-host>:{}/setup in a browser", port);
-                    println!("  Bootstrap token: {}", token);
-                    println!();
+                    eprintln!();
+                    eprintln!("  *** First-time setup ***");
+                    eprintln!("  Open http://<your-host>:{}/setup in a browser", port);
+                    eprintln!("  Bootstrap token: {}", token);
+                    eprintln!();
                 }
                 Err(e) => {
                     tracing::error!("failed to generate bootstrap token: {}", e);


### PR DESCRIPTION
## Summary

Addresses all 10 findings from the post-fix security audit.

### HIGH
- **NEW-02**: Remove voice key decryption fallback — failed decryptions reject the key entirely instead of falling back to unencrypted (downgrade attack)

### MEDIUM
- **NEW-01**: tryDecrypt returns locked indicator when derivedKey is null (not raw ciphertext)
- **NEW-03**: Security headers on all responses (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
- **NEW-06**: CORS restrictive by default, permissive only with DILLA_INSECURE=true
- **NEW-08**: GroupSession chain advance capped at 2000 (prevents DoS)

### LOW
- **NEW-04**: Path traversal validation on upload team_id
- **NEW-09**: Bootstrap token to stderr instead of stdout

### Noted (no code change)
- **NEW-07**: Rate limiting TODO (needs tower-governor)
- **NEW-05**: JWT in WS URL (known WebSocket limitation)
- **NEW-10**: trusted_proxies TODO

## Test plan
- [ ] 1652 client tests pass (exit 0)
- [ ] 660 server tests pass
- [ ] Build and lint clean
- [ ] SonarCloud quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)