### PR TITLE
fix: federation auth, sync limits, typing cleanup, key compare (Round 4)

### DIFF
--- a/client/src-tauri/src/auth_server.rs
+++ b/client/src-tauri/src/auth_server.rs
@@ -56,7 +56,7 @@ fn generate_nonce() -> String {
 
 fn cors_headers() -> Vec<Header> {
     vec![
-        Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap(),
+        Header::from_bytes("Access-Control-Allow-Origin", "null").unwrap(),
         Header::from_bytes("Access-Control-Allow-Methods", "POST, OPTIONS").unwrap(),
         Header::from_bytes("Access-Control-Allow-Headers", "Content-Type").unwrap(),
     ]

--- a/client/src/services/keyStore.ts
+++ b/client/src/services/keyStore.ts
@@ -153,10 +153,11 @@ async function unwrapMekWithRecovery(
 ): Promise<Uint8Array> {
   const actualHash = await sha256Hash(recoveryKey);
   const expectedHash = new Uint8Array(slot.recovery_key_hash);
-  if (actualHash.length !== expectedHash.length ||
-      !actualHash.every((v, i) => v === expectedHash[i])) {
-    throw new Error('Invalid recovery key');
+  let diff = actualHash.length ^ expectedHash.length;
+  for (let i = 0; i < Math.max(actualHash.length, expectedHash.length); i++) {
+    diff |= (actualHash[i] ?? 0) ^ (expectedHash[i] ?? 0);
   }
+  if (diff !== 0) throw new Error('Invalid recovery key');
   const aesKey = await deriveAesFromRecovery(recoveryKey);
   const data = new Uint8Array([...slot.wrapped_nonce, ...slot.wrapped_mek]);
   return aesGcmDecrypt(aesKey, data);

--- a/server-rs/src/federation/mod.rs
+++ b/server-rs/src/federation/mod.rs
@@ -109,7 +109,7 @@ pub struct MeshNode {
 impl MeshNode {
     /// Create a new MeshNode with the given configuration, database, and hub references.
     pub fn new(config: MeshConfig, db: Database, hub: Arc<Hub>) -> Self {
-        let transport = Arc::new(Transport::new());
+        let transport = Arc::new(Transport::with_join_secret(config.join_secret.clone()));
         let sync_mgr = Arc::new(SyncManager::new(
             db.clone(),
             Arc::clone(&transport),

--- a/server-rs/src/federation/sync.rs
+++ b/server-rs/src/federation/sync.rs
@@ -22,6 +22,31 @@ const MAX_SYNC_TOTAL_MESSAGES: usize = 10_000;
 /// Minimum interval between sync requests from the same peer (seconds).
 const SYNC_RATE_LIMIT_SECS: i64 = 300;
 
+/// Validate a state sync response doesn't exceed size limits.
+pub(crate) fn validate_sync_response_size(num_channels: usize, num_messages: usize) -> Result<(), String> {
+    if num_channels > MAX_SYNC_CHANNELS {
+        return Err(format!(
+            "sync response rejected: {} channels exceeds limit of {}",
+            num_channels, MAX_SYNC_CHANNELS
+        ));
+    }
+    if num_messages > MAX_SYNC_TOTAL_MESSAGES {
+        return Err(format!(
+            "sync response rejected: {} messages exceeds limit of {}",
+            num_messages, MAX_SYNC_TOTAL_MESSAGES
+        ));
+    }
+    Ok(())
+}
+
+/// Check if a sync request from a peer should be rate-limited.
+pub(crate) fn is_sync_rate_limited(last_request_ts: Option<i64>, now: i64) -> bool {
+    match last_request_ts {
+        Some(ts) if (now - ts) < SYNC_RATE_LIMIT_SECS => true,
+        _ => false,
+    }
+}
+
 /// Data transferred during a state synchronization exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateSyncData {
@@ -195,20 +220,7 @@ impl SyncManager {
     /// MAX_SYNC_TOTAL_MESSAGES messages to prevent abuse.
     pub async fn handle_state_sync_response(&self, data: StateSyncData) -> Result<(), String> {
         // Validate response size limits.
-        if data.channels.len() > MAX_SYNC_CHANNELS {
-            return Err(format!(
-                "sync response rejected: {} channels exceeds limit of {}",
-                data.channels.len(),
-                MAX_SYNC_CHANNELS
-            ));
-        }
-        if data.messages.len() > MAX_SYNC_TOTAL_MESSAGES {
-            return Err(format!(
-                "sync response rejected: {} messages exceeds limit of {}",
-                data.messages.len(),
-                MAX_SYNC_TOTAL_MESSAGES
-            ));
-        }
+        validate_sync_response_size(data.channels.len(), data.messages.len())?;
 
         let db = self.db.clone();
 
@@ -1101,4 +1113,43 @@ mod tests {
         })
         .unwrap();
     }
+}
+
+    #[test]
+    fn test_validate_sync_response_size_ok() {
+        assert!(validate_sync_response_size(50, 5000).is_ok());
+    }
+
+    #[test]
+    fn test_validate_sync_response_size_too_many_channels() {
+        assert!(validate_sync_response_size(101, 100).is_err());
+    }
+
+    #[test]
+    fn test_validate_sync_response_size_too_many_messages() {
+        assert!(validate_sync_response_size(10, 10001).is_err());
+    }
+
+    #[test]
+    fn test_validate_sync_response_size_at_limit() {
+        assert!(validate_sync_response_size(100, 10000).is_ok());
+    }
+
+    #[test]
+    fn test_is_sync_rate_limited_no_previous() {
+        assert!(!is_sync_rate_limited(None, 1000));
+    }
+
+    #[test]
+    fn test_is_sync_rate_limited_too_soon() {
+        let now = 1000;
+        let last = now - 60; // 60s ago, limit is 300s
+        assert!(is_sync_rate_limited(Some(last), now));
+    }
+
+    #[test]
+    fn test_is_sync_rate_limited_enough_time() {
+        let now = 1000;
+        let last = now - 301; // 301s ago, limit is 300s
+        assert!(!is_sync_rate_limited(Some(last), now));
 }

--- a/server-rs/src/federation/sync.rs
+++ b/server-rs/src/federation/sync.rs
@@ -1,12 +1,26 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use crate::db::{self, Database};
 
 use super::transport::Transport;
 use super::{FederationEvent, FED_EVENT_STATE_SYNC_REQ, FED_EVENT_STATE_SYNC_RESP};
+
+/// Maximum number of messages to load per channel during state sync.
+const MAX_SYNC_MESSAGES_PER_CHANNEL: usize = 1000;
+
+/// Maximum number of channels allowed in a state sync response.
+const MAX_SYNC_CHANNELS: usize = 100;
+
+/// Maximum total messages allowed in a state sync response.
+const MAX_SYNC_TOTAL_MESSAGES: usize = 10_000;
+
+/// Minimum interval between sync requests from the same peer (seconds).
+const SYNC_RATE_LIMIT_SECS: i64 = 300;
 
 /// Data transferred during a state synchronization exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,6 +42,8 @@ pub struct SyncManager {
     db: Database,
     transport: Arc<Transport>,
     node_name: String,
+    /// Tracks the last sync request timestamp per peer for rate limiting.
+    last_sync_request: RwLock<HashMap<String, i64>>,
 }
 
 #[allow(dead_code)]
@@ -38,6 +54,7 @@ impl SyncManager {
             db,
             transport,
             node_name,
+            last_sync_request: RwLock::new(HashMap::new()),
         }
     }
 
@@ -85,10 +102,33 @@ impl SyncManager {
 
     /// Handle an incoming state sync request from a peer.
     ///
-    /// Fetches all channels, messages, members, and roles from the local database
-    /// and sends them back to the requesting peer.
+    /// Fetches channels, messages (up to MAX_SYNC_MESSAGES_PER_CHANNEL per channel),
+    /// members, and roles from the local database and sends them back to the
+    /// requesting peer. Rate-limited to one request per 5 minutes per peer.
     pub async fn handle_state_sync_request(&self, peer_addr: &str) -> Result<(), String> {
+        // Rate limit: max 1 sync request per SYNC_RATE_LIMIT_SECS per peer.
+        {
+            let now = chrono::Utc::now().timestamp();
+            let mut last_sync = self.last_sync_request.write().await;
+            if let Some(&last_ts) = last_sync.get(peer_addr) {
+                if now - last_ts < SYNC_RATE_LIMIT_SECS {
+                    tracing::warn!(
+                        peer = %peer_addr,
+                        "state sync request rate-limited (last request {}s ago, min {}s)",
+                        now - last_ts,
+                        SYNC_RATE_LIMIT_SECS
+                    );
+                    return Err(format!(
+                        "sync rate-limited: must wait {}s between requests",
+                        SYNC_RATE_LIMIT_SECS
+                    ));
+                }
+            }
+            last_sync.insert(peer_addr.to_string(), now);
+        }
+
         let db = self.db.clone();
+        let max_msgs = MAX_SYNC_MESSAGES_PER_CHANNEL;
 
         let sync_data = tokio::task::spawn_blocking(move || {
             db.with_conn(|conn| {
@@ -113,10 +153,10 @@ impl SyncManager {
                 let member_pairs = db::get_members_by_team(conn, &team.id)?;
                 let members: Vec<db::Member> = member_pairs.into_iter().map(|(m, _)| m).collect();
 
-                // Collect recent messages across all channels.
+                // Collect recent messages across all channels, limited per channel.
                 let mut messages = Vec::new();
                 for ch in &channels {
-                    let ch_msgs = db::get_messages_by_channel(conn, &ch.id, "", 100)?;
+                    let ch_msgs = db::get_messages_by_channel(conn, &ch.id, "", max_msgs as i32)?;
                     messages.extend(ch_msgs);
                 }
 
@@ -150,7 +190,26 @@ impl SyncManager {
     /// Uses last-writer-wins conflict resolution: if a remote record has a newer
     /// `updated_at` (or `edited_at` for messages), the local record is overwritten.
     /// New records are inserted. The entire merge runs in a single transaction.
+    ///
+    /// Rejects responses with more than MAX_SYNC_CHANNELS channels or
+    /// MAX_SYNC_TOTAL_MESSAGES messages to prevent abuse.
     pub async fn handle_state_sync_response(&self, data: StateSyncData) -> Result<(), String> {
+        // Validate response size limits.
+        if data.channels.len() > MAX_SYNC_CHANNELS {
+            return Err(format!(
+                "sync response rejected: {} channels exceeds limit of {}",
+                data.channels.len(),
+                MAX_SYNC_CHANNELS
+            ));
+        }
+        if data.messages.len() > MAX_SYNC_TOTAL_MESSAGES {
+            return Err(format!(
+                "sync response rejected: {} messages exceeds limit of {}",
+                data.messages.len(),
+                MAX_SYNC_TOTAL_MESSAGES
+            ));
+        }
+
         let db = self.db.clone();
 
         let channel_count = data.channels.len();

--- a/server-rs/src/federation/transport.rs
+++ b/server-rs/src/federation/transport.rs
@@ -28,6 +28,16 @@ fn validate_auth_message(message_text: &str, expected_secret: &str) -> bool {
     }
 }
 
+/// Build the outbound authentication message JSON.
+fn build_auth_message(join_secret: &str) -> String {
+    serde_json::json!({ "join_token": join_secret }).to_string()
+}
+
+/// Check if federation authentication is required (non-empty secret).
+fn requires_auth(join_secret: &str) -> bool {
+    !join_secret.is_empty()
+}
+
 type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 
 /// Represents a connection to a remote federation peer.
@@ -117,9 +127,9 @@ impl Transport {
         let (mut sink, stream) = ws_stream.split();
 
         // Send join token as the first message (outbound authentication).
-        if !self.join_secret.is_empty() {
-            let auth_msg = serde_json::json!({ "join_token": self.join_secret });
-            sink.send(Message::Text(auth_msg.to_string().into()))
+        if requires_auth(&self.join_secret) {
+            let auth_msg = build_auth_message(&self.join_secret);
+            sink.send(Message::Text(auth_msg.into()))
                 .await
                 .map_err(|e| format!("failed to send auth to peer {}: {}", address, e))?;
         }
@@ -159,7 +169,7 @@ impl Transport {
         let sink = Arc::new(tokio::sync::Mutex::new(sink));
 
         // Authenticate: expect a join_token as the first message within AUTH_TIMEOUT_SECS.
-        if !self.join_secret.is_empty() {
+        if requires_auth(&self.join_secret) {
             let auth_result = tokio::time::timeout(
                 tokio::time::Duration::from_secs(AUTH_TIMEOUT_SECS),
                 stream.next(),
@@ -471,5 +481,34 @@ mod tests {
         let msg = r#"{"join_token":""}"#;
         assert!(!validate_auth_message(msg, "secret"));
         assert!(validate_auth_message(msg, ""));
+    }
+
+    #[test]
+    fn test_build_auth_message() {
+        let msg = build_auth_message("my-secret");
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["join_token"], "my-secret");
+    }
+
+    #[test]
+    fn test_build_auth_message_roundtrip() {
+        let secret = "test-join-secret-123";
+        let msg = build_auth_message(secret);
+        assert!(validate_auth_message(&msg, secret));
+    }
+
+    #[test]
+    fn test_requires_auth_with_secret() {
+        assert!(requires_auth("my-secret"));
+    }
+
+    #[test]
+    fn test_requires_auth_empty() {
+        assert!(!requires_auth(""));
+    }
+
+    #[test]
+    fn test_auth_timeout_constant() {
+        assert_eq!(AUTH_TIMEOUT_SECS, 5);
     }
 }

--- a/server-rs/src/federation/transport.rs
+++ b/server-rs/src/federation/transport.rs
@@ -3,12 +3,30 @@ use std::sync::Arc;
 
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use super::FederationEvent;
+
+/// Timeout for the peer to send a join token after connecting.
+const AUTH_TIMEOUT_SECS: u64 = 5;
+
+/// JSON payload expected as the first message from a connecting peer.
+#[derive(Debug, Deserialize)]
+struct AuthMessage {
+    join_token: String,
+}
+
+/// Validate an authentication message against the expected join secret.
+fn validate_auth_message(message_text: &str, expected_secret: &str) -> bool {
+    match serde_json::from_str::<AuthMessage>(message_text) {
+        Ok(auth) => auth.join_token == expected_secret,
+        Err(_) => false,
+    }
+}
 
 type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 
@@ -31,6 +49,7 @@ pub struct Transport {
     conns: Arc<RwLock<HashMap<String, PeerConnection>>>,
     peers: Arc<RwLock<Vec<String>>>,
     on_event: Arc<RwLock<Option<OnEventFn>>>,
+    join_secret: String,
     stop_tx: tokio::sync::watch::Sender<bool>,
     stop_rx: tokio::sync::watch::Receiver<bool>,
 }
@@ -56,11 +75,16 @@ fn build_peer_url(address: &str) -> String {
 #[allow(dead_code)]
 impl Transport {
     pub fn new() -> Self {
+        Self::with_join_secret(String::new())
+    }
+
+    pub fn with_join_secret(join_secret: String) -> Self {
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
         Transport {
             conns: Arc::new(RwLock::new(HashMap::new())),
             peers: Arc::new(RwLock::new(Vec::new())),
             on_event: Arc::new(RwLock::new(None)),
+            join_secret,
             stop_tx,
             stop_rx,
         }
@@ -90,7 +114,16 @@ impl Transport {
             .await
             .map_err(|e| format!("failed to connect to peer {}: {}", address, e))?;
 
-        let (sink, stream) = ws_stream.split();
+        let (mut sink, stream) = ws_stream.split();
+
+        // Send join token as the first message (outbound authentication).
+        if !self.join_secret.is_empty() {
+            let auth_msg = serde_json::json!({ "join_token": self.join_secret });
+            sink.send(Message::Text(auth_msg.to_string().into()))
+                .await
+                .map_err(|e| format!("failed to send auth to peer {}: {}", address, e))?;
+        }
+
         let sink = Arc::new(tokio::sync::Mutex::new(sink));
 
         {
@@ -114,15 +147,37 @@ impl Transport {
 
     /// Handle an incoming WebSocket connection from a remote peer.
     ///
-    /// Accepts the connection, registers it in the connection map, and spawns a
-    /// read-pump task.
+    /// Accepts the connection, authenticates the peer by expecting a join token
+    /// as the first message within 5 seconds, registers it in the connection map,
+    /// and spawns a read-pump task.
     pub async fn handle_incoming(
         &self,
         peer_addr: &str,
         ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
     ) {
-        let (sink, stream) = ws_stream.split();
+        let (sink, mut stream) = ws_stream.split();
         let sink = Arc::new(tokio::sync::Mutex::new(sink));
+
+        // Authenticate: expect a join_token as the first message within AUTH_TIMEOUT_SECS.
+        if !self.join_secret.is_empty() {
+            let auth_result = tokio::time::timeout(
+                tokio::time::Duration::from_secs(AUTH_TIMEOUT_SECS),
+                stream.next(),
+            )
+            .await;
+
+            let authenticated = match auth_result {
+                Ok(Some(Ok(Message::Text(text)))) => validate_auth_message(&text, &self.join_secret),
+                _ => false,
+            };
+
+            if !authenticated {
+                tracing::warn!(peer = %peer_addr, "federation peer failed authentication — disconnecting");
+                let mut s = sink.lock().await;
+                let _ = s.send(Message::Close(None)).await;
+                return;
+            }
+        }
 
         {
             let mut conns = self.conns.write().await;
@@ -143,7 +198,7 @@ impl Transport {
             }
         }
 
-        tracing::info!(peer = %peer_addr, "accepted incoming federation peer");
+        tracing::info!(peer = %peer_addr, "accepted incoming federation peer (authenticated)");
 
         self.spawn_read_pump(peer_addr.to_string(), stream);
     }
@@ -386,5 +441,35 @@ mod tests {
             build_peer_url("node2.local"),
             "wss://node2.local/federation"
         );
+    }
+
+    #[test]
+    fn test_validate_auth_message_valid() {
+        let msg = r#"{"join_token":"my-secret"}"#;
+        assert!(validate_auth_message(msg, "my-secret"));
+    }
+
+    #[test]
+    fn test_validate_auth_message_wrong_token() {
+        let msg = r#"{"join_token":"wrong"}"#;
+        assert!(!validate_auth_message(msg, "my-secret"));
+    }
+
+    #[test]
+    fn test_validate_auth_message_invalid_json() {
+        assert!(!validate_auth_message("not json", "secret"));
+    }
+
+    #[test]
+    fn test_validate_auth_message_missing_field() {
+        let msg = r#"{"other":"value"}"#;
+        assert!(!validate_auth_message(msg, "secret"));
+    }
+
+    #[test]
+    fn test_validate_auth_message_empty_token() {
+        let msg = r#"{"join_token":""}"#;
+        assert!(!validate_auth_message(msg, "secret"));
+        assert!(validate_auth_message(msg, ""));
     }
 }

--- a/server-rs/src/ws/hub.rs
+++ b/server-rs/src/ws/hub.rs
@@ -137,6 +137,9 @@ impl Hub {
         let mut direct_rx = self.direct_rx.lock().await;
         let mut broadcast_all_rx = self.broadcast_all_rx.lock().await;
 
+        // Periodic cleanup interval for typing_throttle (every 60 seconds).
+        let mut cleanup_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+
         loop {
             tokio::select! {
                 Some(client) = register_rx.recv() => {
@@ -219,6 +222,12 @@ impl Hub {
                     for client in clients.values() {
                         let _ = client.sender.send(data.clone());
                     }
+                }
+                _ = cleanup_interval.tick() => {
+                    // Remove typing throttle entries older than 10 seconds.
+                    let now = chrono::Utc::now().timestamp();
+                    let mut throttle = self.typing_throttle.write().await;
+                    throttle.retain(|_, ts| now - *ts < 10);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes all 5 findings from Round 4 security audit.

### MEDIUM
- **R4-01**: Federation transport requires peer authentication via join_token
- **R4-02**: State sync rate-limited (1/5min per peer) and size-capped (100 channels, 10K messages)
- **R4-03**: Typing throttle map cleaned up every 60s (prevents memory leak)

### LOW
- **R4-04**: Tauri auth callback CORS restricted from `*` to `null`
- **R4-05**: Recovery key hash uses constant-time XOR comparison

## Test plan
- [ ] 687 server tests pass
- [ ] 1655 client tests pass
- [ ] Build and lint clean
- [ ] SonarCloud quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)