### PR TITLE
fix: typing throttle cleanup, constant-time key compare, Tauri CORS (R4 Part A)

### DIFF
--- a/client/src-tauri/src/auth_server.rs
+++ b/client/src-tauri/src/auth_server.rs
@@ -56,7 +56,7 @@ fn generate_nonce() -> String {
 
 fn cors_headers() -> Vec<Header> {
     vec![
-        Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap(),
+        Header::from_bytes("Access-Control-Allow-Origin", "null").unwrap(),
         Header::from_bytes("Access-Control-Allow-Methods", "POST, OPTIONS").unwrap(),
         Header::from_bytes("Access-Control-Allow-Headers", "Content-Type").unwrap(),
     ]

--- a/client/src/services/keyStore.ts
+++ b/client/src/services/keyStore.ts
@@ -153,10 +153,11 @@ async function unwrapMekWithRecovery(
 ): Promise<Uint8Array> {
   const actualHash = await sha256Hash(recoveryKey);
   const expectedHash = new Uint8Array(slot.recovery_key_hash);
-  if (actualHash.length !== expectedHash.length ||
-      !actualHash.every((v, i) => v === expectedHash[i])) {
-    throw new Error('Invalid recovery key');
+  let diff = actualHash.length ^ expectedHash.length;
+  for (let i = 0; i < Math.max(actualHash.length, expectedHash.length); i++) {
+    diff |= (actualHash[i] ?? 0) ^ (expectedHash[i] ?? 0);
   }
+  if (diff !== 0) throw new Error('Invalid recovery key');
   const aesKey = await deriveAesFromRecovery(recoveryKey);
   const data = new Uint8Array([...slot.wrapped_nonce, ...slot.wrapped_mek]);
   return aesGcmDecrypt(aesKey, data);

--- a/server-rs/src/ws/hub.rs
+++ b/server-rs/src/ws/hub.rs
@@ -137,6 +137,9 @@ impl Hub {
         let mut direct_rx = self.direct_rx.lock().await;
         let mut broadcast_all_rx = self.broadcast_all_rx.lock().await;
 
+        // Periodic cleanup interval for typing_throttle (every 60 seconds).
+        let mut cleanup_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+
         loop {
             tokio::select! {
                 Some(client) = register_rx.recv() => {
@@ -219,6 +222,12 @@ impl Hub {
                     for client in clients.values() {
                         let _ = client.sender.send(data.clone());
                     }
+                }
+                _ = cleanup_interval.tick() => {
+                    // Remove typing throttle entries older than 10 seconds.
+                    let now = chrono::Utc::now().timestamp();
+                    let mut throttle = self.typing_throttle.write().await;
+                    throttle.retain(|_, ts| now - *ts < 10);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Part A of Round 4 security fixes — testable changes only.

- **R4-03 (MEDIUM)**: Typing throttle map cleaned up every 60s (prevents memory leak)
- **R4-04 (LOW)**: Tauri auth callback CORS restricted from `*` to `null`
- **R4-05 (LOW)**: Recovery key hash uses constant-time XOR comparison

Part B (federation auth + sync limits) will be a separate PR requiring integration test infrastructure.

## Test plan
- [ ] 682 server tests pass
- [ ] 1655 client tests pass
- [ ] Build and lint clean
- [ ] SonarCloud quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)