### PR TITLE
feat: FK enforcement, HSTS header, account deletion API

### DIFF
--- a/server-rs/migrations/007_nullable_fks.sql
+++ b/server-rs/migrations/007_nullable_fks.sql
@@ -1,0 +1,51 @@
+-- Migration 007: Make optional FK columns nullable for proper foreign key enforcement.
+-- SQLite requires table recreation to change NOT NULL constraints.
+
+-- Step 1: Recreate messages table with nullable channel_id.
+-- channel_id is NULL for DM messages; dm_channel_id is NULL for channel messages.
+CREATE TABLE messages_new (
+    id TEXT PRIMARY KEY,
+    channel_id TEXT REFERENCES channels(id) ON DELETE CASCADE,
+    author_id TEXT NOT NULL REFERENCES users(id),
+    content BLOB NOT NULL,
+    type TEXT NOT NULL DEFAULT 'text' CHECK(type IN ('text', 'system', 'file')),
+    thread_id TEXT,
+    edited_at TEXT,
+    deleted INTEGER NOT NULL DEFAULT 0,
+    lamport_ts INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    dm_channel_id TEXT REFERENCES dm_channels(id)
+);
+
+INSERT INTO messages_new (id, channel_id, author_id, content, type, thread_id, edited_at, deleted, lamport_ts, created_at, dm_channel_id)
+    SELECT id, NULLIF(channel_id, ''), author_id, content, type, NULLIF(thread_id, ''),
+           edited_at, deleted, lamport_ts, created_at, NULLIF(dm_channel_id, '')
+    FROM messages;
+
+DROP TABLE messages;
+ALTER TABLE messages_new RENAME TO messages;
+CREATE INDEX IF NOT EXISTS idx_messages_channel ON messages(channel_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
+CREATE INDEX IF NOT EXISTS idx_messages_dm_channel ON messages(dm_channel_id);
+
+-- Step 2: Recreate attachments table with nullable message_id.
+-- message_id is NULL when the attachment is uploaded but not yet linked to a message.
+CREATE TABLE attachments_new (
+    id TEXT PRIMARY KEY,
+    message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
+    filename_encrypted BLOB NOT NULL,
+    content_type_encrypted BLOB,
+    size INTEGER NOT NULL,
+    storage_path TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO attachments_new (id, message_id, filename_encrypted, content_type_encrypted, size, storage_path, created_at)
+    SELECT id, NULLIF(message_id, ''), filename_encrypted, content_type_encrypted, size, storage_path, created_at
+    FROM attachments;
+
+DROP TABLE attachments;
+ALTER TABLE attachments_new RENAME TO attachments;
+
+-- Step 3: Convert empty-string FK values to NULL in other tables.
+UPDATE dm_channels SET team_id = NULL WHERE team_id = '';

--- a/server-rs/src/api/mod.rs
+++ b/server-rs/src/api/mod.rs
@@ -111,7 +111,7 @@ pub fn create_router(state: AppState) -> Router {
     // Protected routes (auth required).
     let protected = Router::new()
         // Users
-        .route("/api/v1/users/me", get(users::get_me).patch(users::update_me))
+        .route("/api/v1/users/me", get(users::get_me).patch(users::update_me).delete(users::delete_me))
         // Identity blob
         .route(
             "/api/v1/identity/blob",
@@ -275,7 +275,7 @@ pub fn create_router(state: AppState) -> Router {
     let ws_route = Router::new()
         .route("/ws", get(ws_handler));
 
-    Router::new()
+    let mut router = Router::new()
         .merge(public)
         .merge(protected)
         .merge(ws_route)
@@ -294,7 +294,17 @@ pub fn create_router(state: AppState) -> Router {
             HeaderValue::from_static("strict-origin-when-cross-origin"),
         ))
         .fallback_service(crate::webapp::webapp_fallback())
-        .with_state(state)
+        .with_state(state.clone());
+
+    // Add HSTS header only when TLS is configured.
+    if !state.config.tls_cert.is_empty() && !state.config.tls_key.is_empty() {
+        router = router.layer(SetResponseHeaderLayer::if_not_present(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ));
+    }
+
+    router
 }
 
 async fn health() -> Json<serde_json::Value> {

--- a/server-rs/src/api/users.rs
+++ b/server-rs/src/api/users.rs
@@ -105,6 +105,26 @@ pub async fn get_identity_blob(
     })))
 }
 
+pub async fn delete_me(
+    Extension(UserId(user_id)): Extension<UserId>,
+    State(state): State<AppState>,
+) -> Result<Json<Value>, AppError> {
+    let db = state.db.clone();
+    let uid = user_id.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| db::delete_user(conn, &uid))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("task join: {}", e)))?;
+
+    match result {
+        Ok(()) => Ok(Json(json!({ "ok": true }))),
+        Err(rusqlite::Error::InvalidParameterName(msg)) => Err(AppError::BadRequest(msg)),
+        Err(e) => Err(AppError::Internal(format!("db: {}", e))),
+    }
+}
+
 pub async fn put_identity_blob(
     Extension(UserId(user_id)): Extension<UserId>,
     State(state): State<AppState>,

--- a/server-rs/src/db/attachment_queries.rs
+++ b/server-rs/src/db/attachment_queries.rs
@@ -1,4 +1,5 @@
 use super::models::*;
+use super::nullable;
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub fn create_attachment(conn: &Connection, att: &Attachment) -> Result<(), rusqlite::Error> {
@@ -7,7 +8,7 @@ pub fn create_attachment(conn: &Connection, att: &Attachment) -> Result<(), rusq
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             att.id,
-            att.message_id,
+            nullable(&att.message_id),
             att.filename_encrypted,
             att.content_type_encrypted,
             att.size,
@@ -52,7 +53,7 @@ pub fn delete_attachment(conn: &Connection, id: &str) -> Result<(), rusqlite::Er
 fn row_to_attachment(row: &rusqlite::Row) -> Result<Attachment, rusqlite::Error> {
     Ok(Attachment {
         id: row.get(0)?,
-        message_id: row.get(1)?,
+        message_id: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
         filename_encrypted: row.get(2)?,
         content_type_encrypted: row.get::<_, Option<Vec<u8>>>(3)?.unwrap_or_default(),
         size: row.get(4)?,

--- a/server-rs/src/db/dm_queries.rs
+++ b/server-rs/src/db/dm_queries.rs
@@ -1,11 +1,11 @@
 use super::models::*;
-use super::{now_str, row_to_message};
+use super::{nullable, now_str, row_to_message};
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub fn create_dm_channel(conn: &Connection, dm: &DMChannel) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT INTO dm_channels (id, team_id, type, name, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![dm.id, dm.team_id, dm.dm_type, dm.name, dm.created_at],
+        params![dm.id, nullable(&dm.team_id), dm.dm_type, dm.name, dm.created_at],
     )?;
     Ok(())
 }
@@ -116,7 +116,7 @@ pub fn is_dm_member(
 pub fn create_dm_message(conn: &Connection, msg: &Message) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT INTO messages (id, channel_id, dm_channel_id, author_id, content, type, lamport_ts, created_at)
-         VALUES (?1, '', ?2, ?3, ?4, ?5, ?6, ?7)",
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             msg.id,
             msg.dm_channel_id,

--- a/server-rs/src/db/message_queries.rs
+++ b/server-rs/src/db/message_queries.rs
@@ -1,5 +1,5 @@
 use super::models::*;
-use super::{now_str, row_to_message};
+use super::{nullable, now_str, row_to_message};
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub fn create_message(conn: &Connection, msg: &Message) -> Result<(), rusqlite::Error> {
@@ -8,12 +8,12 @@ pub fn create_message(conn: &Connection, msg: &Message) -> Result<(), rusqlite::
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         params![
             msg.id,
-            msg.channel_id,
-            if msg.dm_channel_id.is_empty() { None } else { Some(&msg.dm_channel_id) },
+            nullable(&msg.channel_id),
+            nullable(&msg.dm_channel_id),
             msg.author_id,
             msg.content,
             msg.msg_type,
-            if msg.thread_id.is_empty() { None } else { Some(&msg.thread_id) },
+            nullable(&msg.thread_id),
             msg.lamport_ts,
             msg.created_at,
         ],
@@ -43,7 +43,7 @@ pub fn get_messages_by_channel(
     let mut messages = if before.is_empty() {
         let mut stmt = conn.prepare(
             "SELECT id, channel_id, dm_channel_id, author_id, content, type, thread_id, edited_at, deleted, lamport_ts, created_at
-             FROM messages WHERE channel_id = ?1 AND (thread_id IS NULL OR thread_id = '')
+             FROM messages WHERE channel_id = ?1 AND thread_id IS NULL
              ORDER BY created_at DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![channel_id, limit], row_to_message)?;
@@ -51,7 +51,7 @@ pub fn get_messages_by_channel(
     } else {
         let mut stmt = conn.prepare(
             "SELECT id, channel_id, dm_channel_id, author_id, content, type, thread_id, edited_at, deleted, lamport_ts, created_at
-             FROM messages WHERE channel_id = ?1 AND (thread_id IS NULL OR thread_id = '') AND created_at < ?2
+             FROM messages WHERE channel_id = ?1 AND thread_id IS NULL AND created_at < ?2
              ORDER BY created_at DESC LIMIT ?3",
         )?;
         let rows = stmt.query_map(params![channel_id, before, limit], |row| {

--- a/server-rs/src/db/mod.rs
+++ b/server-rs/src/db/mod.rs
@@ -48,6 +48,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("004_threads.sql", include_str!("../../migrations/004_threads.sql")),
     ("005_reactions_attachments.sql", include_str!("../../migrations/005_reactions_attachments.sql")),
     ("006_federation_sync.sql", include_str!("../../migrations/006_federation_sync.sql")),
+    ("007_nullable_fks.sql", include_str!("../../migrations/007_nullable_fks.sql")),
 ];
 
 /// Default number of read connections in the pool.
@@ -74,6 +75,7 @@ fn open_connection(db_path: &Path, passphrase: &str) -> Result<Connection, rusql
     }
     conn.execute_batch("PRAGMA journal_mode = WAL;")?;
     conn.execute_batch("PRAGMA busy_timeout = 5000;")?;
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
     conn.execute_batch("SELECT 1;")?;
     Ok(conn)
 }
@@ -216,7 +218,44 @@ pub fn new_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// Convert an empty string to `None` for nullable FK columns.
+/// Use in `params![]` so that empty strings are stored as SQL NULL,
+/// which correctly skips foreign key checks.
+pub fn nullable(s: &str) -> Option<&str> {
+    if s.is_empty() { None } else { Some(s) }
+}
+
 /// Format current time as SQLite datetime string.
 pub fn now_str() -> String {
     chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+#[cfg(test)]
+mod nullable_tests {
+    use super::*;
+
+    #[test]
+    fn nullable_returns_none_for_empty() {
+        assert_eq!(nullable(""), None);
+    }
+
+    #[test]
+    fn nullable_returns_some_for_non_empty() {
+        assert_eq!(nullable("hello"), Some("hello"));
+    }
+
+    #[test]
+    fn foreign_keys_enabled_on_new_connections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(tmp.path().to_str().unwrap(), "").unwrap();
+        let fk_enabled: i32 = db
+            .with_conn(|c| c.query_row("PRAGMA foreign_keys", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(fk_enabled, 1, "foreign_keys should be ON for write conn");
+
+        let fk_read: i32 = db
+            .with_read(|c| c.query_row("PRAGMA foreign_keys", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(fk_read, 1, "foreign_keys should be ON for read conns");
+    }
 }

--- a/server-rs/src/db/thread_queries.rs
+++ b/server-rs/src/db/thread_queries.rs
@@ -1,5 +1,5 @@
 use super::models::*;
-use super::{now_str, row_to_message};
+use super::{nullable, now_str, row_to_message};
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub fn create_thread(conn: &Connection, thread: &Thread) -> Result<(), rusqlite::Error> {

--- a/server-rs/src/db/user_queries.rs
+++ b/server-rs/src/db/user_queries.rs
@@ -83,6 +83,75 @@ pub fn update_user_status(
     Ok(())
 }
 
+/// Delete a user and all their data (GDPR right to erasure).
+///
+/// Removes all user-owned data in the correct order to satisfy FK constraints.
+/// Messages are hard-deleted (E2E encrypted content is meaningless without keys).
+/// Returns an error if the user is the sole admin of any team.
+pub fn delete_user(conn: &Connection, user_id: &str) -> Result<(), rusqlite::Error> {
+    // 1. Check that the user isn't the sole admin of any team.
+    let sole_admin_count: i32 = conn.query_row(
+        "SELECT COUNT(*) FROM teams t
+         WHERE t.created_by = ?1
+         AND NOT EXISTS (
+             SELECT 1 FROM members m
+             JOIN member_roles mr ON mr.member_id = m.id
+             JOIN roles r ON r.id = mr.role_id
+             WHERE m.team_id = t.id AND m.user_id != ?1 AND r.permissions & 1 != 0
+         )",
+        [user_id],
+        |row| row.get(0),
+    )?;
+    if sole_admin_count > 0 {
+        return Err(rusqlite::Error::InvalidParameterName(
+            "cannot delete: user is the sole admin of a team — transfer ownership first".into(),
+        ));
+    }
+
+    // 2. Delete reactions by user.
+    conn.execute("DELETE FROM reactions WHERE user_id = ?1", [user_id])?;
+    // 3. Delete attachments for user's messages.
+    conn.execute(
+        "DELETE FROM attachments WHERE message_id IN (SELECT id FROM messages WHERE author_id = ?1)",
+        [user_id],
+    )?;
+    // 4. Delete threads created by user (cascades to thread messages via thread_id).
+    conn.execute(
+        "DELETE FROM messages WHERE thread_id IN (SELECT id FROM threads WHERE creator_id = ?1)",
+        [user_id],
+    )?;
+    conn.execute("DELETE FROM threads WHERE creator_id = ?1", [user_id])?;
+    // 5. Hard-delete user's messages (GDPR erasure).
+    conn.execute("DELETE FROM messages WHERE author_id = ?1", [user_id])?;
+    // 6. Delete DM memberships.
+    conn.execute("DELETE FROM dm_members WHERE user_id = ?1", [user_id])?;
+    // 7. Delete invite uses.
+    conn.execute("DELETE FROM invite_uses WHERE user_id = ?1", [user_id])?;
+    // 8. Delete invites created by user.
+    conn.execute("DELETE FROM invites WHERE created_by = ?1", [user_id])?;
+    // 9. Delete bans (both as target and as banner).
+    conn.execute("DELETE FROM bans WHERE user_id = ?1 OR banned_by = ?1", [user_id])?;
+    // 10. Delete prekey bundles.
+    conn.execute("DELETE FROM prekey_bundles WHERE user_id = ?1", [user_id])?;
+    // 11. Nullify optional FK references.
+    conn.execute("UPDATE channels SET created_by = NULL WHERE created_by = ?1", [user_id])?;
+    conn.execute("UPDATE members SET invited_by = NULL WHERE invited_by = ?1", [user_id])?;
+    // 12. Delete member_roles and members.
+    conn.execute(
+        "DELETE FROM member_roles WHERE member_id IN (SELECT id FROM members WHERE user_id = ?1)",
+        [user_id],
+    )?;
+    conn.execute("DELETE FROM members WHERE user_id = ?1", [user_id])?;
+    // 13. Delete identity blob.
+    conn.execute(
+        "DELETE FROM settings WHERE key = 'identity_blob:' || ?1",
+        [user_id],
+    )?;
+    // 14. Finally delete the user.
+    conn.execute("DELETE FROM users WHERE id = ?1", [user_id])?;
+    Ok(())
+}
+
 fn row_to_user(row: &rusqlite::Row) -> Result<User, rusqlite::Error> {
     Ok(User {
         id: row.get(0)?,
@@ -200,6 +269,78 @@ mod tests {
         let user2 = make_user("u2", "user_b", &pk);
         db.with_conn(|c| create_user(c, &user1)).unwrap();
         let result = db.with_conn(|c| create_user(c, &user2));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_user_removes_all_data() {
+        let db = test_db();
+        let user = make_user("u1", "alice", &[1u8; 32]);
+        db.with_conn(|c| create_user(c, &user)).unwrap();
+
+        db.with_conn(|c| delete_user(c, "u1")).unwrap();
+
+        let result = db.with_conn(|c| get_user_by_id(c, "u1")).unwrap();
+        assert!(result.is_none());
+        assert!(!db.has_users().unwrap());
+    }
+
+    #[test]
+    fn test_delete_user_with_messages_and_team() {
+        let db = test_db();
+        let user1 = make_user("u1", "alice", &[1u8; 32]);
+        let user2 = make_user("u2", "bob", &[2u8; 32]);
+        db.with_conn(|c| create_user(c, &user1)).unwrap();
+        db.with_conn(|c| create_user(c, &user2)).unwrap();
+
+        let team = make_team("t1", "Team", "u1");
+        db.with_conn(|c| crate::db::create_team(c, &team)).unwrap();
+        let ch = make_channel("ch1", "t1", "general", "u1");
+        db.with_conn(|c| crate::db::create_channel(c, &ch)).unwrap();
+        let m1 = make_member("m1", "t1", "u1");
+        db.with_conn(|c| crate::db::create_member(c, &m1)).unwrap();
+        let m2 = make_member("m2", "t1", "u2");
+        db.with_conn(|c| crate::db::create_member(c, &m2)).unwrap();
+
+        // Give u2 admin role so u1 isn't sole admin.
+        let role = crate::db::Role {
+            id: "r1".into(),
+            team_id: "t1".into(),
+            name: "Admin".into(),
+            color: "#000".into(),
+            position: 0,
+            permissions: 1, // PERM_ADMIN
+            is_default: false,
+            created_at: crate::db::now_str(),
+            updated_at: String::new(),
+        };
+        db.with_conn(|c| crate::db::create_role(c, &role)).unwrap();
+        db.with_conn(|c| crate::db::assign_role_to_member(c, "m2", "r1")).unwrap();
+
+        let msg = make_message("msg1", "ch1", "u1", "hello");
+        db.with_conn(|c| crate::db::create_message(c, &msg)).unwrap();
+
+        // Delete u1.
+        db.with_conn(|c| delete_user(c, "u1")).unwrap();
+
+        // User is gone.
+        assert!(db.with_conn(|c| get_user_by_id(c, "u1")).unwrap().is_none());
+        // Message is gone.
+        assert!(db.with_conn(|c| crate::db::get_message_by_id(c, "msg1")).unwrap().is_none());
+        // Team and other user still exist.
+        assert!(db.with_conn(|c| get_user_by_id(c, "u2")).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_delete_sole_admin_fails() {
+        let db = test_db();
+        let user = make_user("u1", "alice", &[1u8; 32]);
+        db.with_conn(|c| create_user(c, &user)).unwrap();
+
+        let team = make_team("t1", "Team", "u1");
+        db.with_conn(|c| crate::db::create_team(c, &team)).unwrap();
+
+        let result = db.with_conn(|c| delete_user(c, "u1"));
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- **PRAGMA foreign_keys = ON** on all DB connections with migration 007 to convert empty-string FK values to NULL and make columns properly nullable
- **HSTS header** (max-age=2y, includeSubDomains, preload) added when TLS is configured
- **DELETE /api/v1/users/me** endpoint for GDPR account deletion — cascades through all user data (messages, reactions, DM memberships, prekeys, bans, invites, member records), prevents deletion when user is sole team admin

## Test plan
- [x] 709 tests pass (6 new: delete_user x3, nullable x2, FK enforcement check)
- [x] Tarpaulin coverage: 76.35% overall, 100% on changed query files
- [x] SonarCloud quality gate: OK (88.5% new code coverage, 0.2% duplication)
- [ ] Verify migration runs on existing databases (empty strings → NULL)
- [ ] Verify account deletion endpoint works end-to-end
- [ ] Verify HSTS header present when TLS configured, absent otherwise