### PR TITLE
fix: UI polish — resize handle, search bar, mute toggle

### DIFF
--- a/client/src/components/SearchBar/SearchBar.css
+++ b/client/src/components/SearchBar/SearchBar.css
@@ -11,7 +11,8 @@
   border-radius: var(--radius-lg);
   padding: 0 var(--spacing-sm);
   height: 28px;
-  width: calc(var(--member-sidebar-width) - var(--spacing-2xl));
+  flex: 1;
+  min-width: 0;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-sizing: border-box;
 }

--- a/client/src/components/SearchBar/SearchBar.css
+++ b/client/src/components/SearchBar/SearchBar.css
@@ -11,8 +11,7 @@
   border-radius: var(--radius-lg);
   padding: 0 var(--spacing-sm);
   height: 28px;
-  flex: 1;
-  min-width: 0;
+  width: calc(var(--member-sidebar-width) - var(--spacing-2xl));
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-sizing: border-box;
 }

--- a/client/src/components/SearchBar/SearchBar.css
+++ b/client/src/components/SearchBar/SearchBar.css
@@ -11,13 +11,12 @@
   border-radius: var(--radius-lg);
   padding: 0 var(--spacing-sm);
   height: 28px;
-  width: 200px;
-  transition: width 0.2s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  width: var(--member-sidebar-width);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-sizing: border-box;
 }
 
 .header-search-input-wrapper.focused {
-  width: 300px;
   border-color: var(--brand-500);
   box-shadow: 0 0 0 2px var(--brand-alpha-12);
 }

--- a/client/src/components/SearchBar/SearchBar.css
+++ b/client/src/components/SearchBar/SearchBar.css
@@ -11,7 +11,8 @@
   border-radius: var(--radius-lg);
   padding: 0 var(--spacing-sm);
   height: 28px;
-  width: var(--member-sidebar-width);
+  flex: 1;
+  min-width: 0;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-sizing: border-box;
 }

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -150,6 +150,7 @@
   display: flex;
   gap: var(--spacing-sm);
   margin-left: auto;
+  width: calc(var(--member-sidebar-width) - var(--spacing-lg));
   flex-shrink: 0;
 }
 

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -150,7 +150,6 @@
   display: flex;
   gap: var(--spacing-sm);
   margin-left: auto;
-  width: var(--member-sidebar-width);
   flex-shrink: 0;
 }
 

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -148,8 +148,10 @@
 
 .content-header-actions {
   display: flex;
-  gap: var(--spacing-lg);
+  gap: var(--spacing-sm);
   margin-left: auto;
+  width: var(--member-sidebar-width);
+  flex-shrink: 0;
 }
 
 .header-action-btn {

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -38,6 +38,7 @@
   flex-direction: column;
   height: 100%;
   flex-shrink: 0;
+  width: calc(var(--team-sidebar-width) + var(--channel-sidebar-width));
 }
 
 .left-panels-top {

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -38,7 +38,6 @@
   flex-direction: column;
   height: 100%;
   flex-shrink: 0;
-  width: calc(var(--team-sidebar-width) + var(--channel-sidebar-width));
 }
 
 .left-panels-top {

--- a/client/src/pages/AppLayout.tsx
+++ b/client/src/pages/AppLayout.tsx
@@ -107,7 +107,7 @@ export default function AppLayout() {
   const [channelWidth, setChannelWidth] = useState(240);
 
   const handleChannelResize = useCallback((delta: number) => {
-    setChannelWidth(prev => Math.min(Math.max(prev + delta, 180), 340));
+    setChannelWidth(prev => Math.min(Math.max(prev + delta, 240), 400));
   }, []);
 
   // Get current user info from auth store
@@ -435,7 +435,7 @@ export default function AppLayout() {
       <div className={`app-layout-main ${isMobile ? 'mobile' : ''}`}>
       {!isMobile && (
         <>
-          <div className="left-panels">
+          <div className="left-panels" style={{ width: 72 + channelWidth }}>
             <div className="left-panels-top">
               <TeamSidebar />
               {channelSidebarContent}

--- a/client/src/pages/AppLayout.tsx
+++ b/client/src/pages/AppLayout.tsx
@@ -196,7 +196,6 @@ export default function AppLayout() {
             </>
           )}
           <div className="content-header-actions">
-            <SearchBar onJumpToMessage={handleJumpToMessage} />
             {activeDM.is_group && (
               <button
                 className={`header-action-btn ${showDMMembers ? 'active' : ''}`}
@@ -206,6 +205,7 @@ export default function AppLayout() {
                 <Group width={20} height={20} strokeWidth={2} />
               </button>
             )}
+            <SearchBar onJumpToMessage={handleJumpToMessage} />
           </div>
         </>
       );
@@ -229,7 +229,6 @@ export default function AppLayout() {
             </>
           )}
           <div className="content-header-actions">
-            <SearchBar onJumpToMessage={handleJumpToMessage} />
             <button
               className={`header-action-btn ${showMembers ? 'active' : ''}`}
               onClick={() => setShowMembers(v => !v)}
@@ -237,6 +236,7 @@ export default function AppLayout() {
             >
               <Group width={20} height={20} strokeWidth={2} />
             </button>
+            <SearchBar onJumpToMessage={handleJumpToMessage} />
           </div>
         </>
       );
@@ -245,7 +245,6 @@ export default function AppLayout() {
       <>
         <span className="content-header-name title">{t('app.name')}</span>
         <div className="content-header-actions">
-          <SearchBar onJumpToMessage={handleJumpToMessage} />
           <button
             className={`header-action-btn ${showMembers ? 'active' : ''}`}
             onClick={() => setShowMembers(!showMembers)}
@@ -253,6 +252,7 @@ export default function AppLayout() {
           >
             <Group width={20} height={20} strokeWidth={2} />
           </button>
+          <SearchBar onJumpToMessage={handleJumpToMessage} />
         </div>
       </>
     );

--- a/client/src/services/webrtc/WebRTCService.test.ts
+++ b/client/src/services/webrtc/WebRTCService.test.ts
@@ -442,6 +442,20 @@ describe('WebRTCService', () => {
   });
 
   describe('toggleDeafen', () => {
+    it('toggles deafen state when not connected (pre-set)', async () => {
+      const result = await webrtcService.toggleDeafen();
+      expect(result).toBe(true);
+      expect(useVoiceStore.getState().deafened).toBe(true);
+      expect(useVoiceStore.getState().muted).toBe(true); // deafen also mutes
+    });
+
+    it('toggles deafen off when not connected', async () => {
+      useVoiceStore.setState({ deafened: true, muted: true });
+      const result = await webrtcService.toggleDeafen();
+      expect(result).toBe(false);
+      expect(useVoiceStore.getState().deafened).toBe(false);
+    });
+
     it('toggles deafen and sends via websocket', async () => {
       await webrtcService.connect('ch-1', 'team-1');
       const deafened = await webrtcService.toggleDeafen();

--- a/client/src/services/webrtc/WebRTCService.test.ts
+++ b/client/src/services/webrtc/WebRTCService.test.ts
@@ -409,9 +409,10 @@ describe('WebRTCService', () => {
       expect(typeof muted).toBe('boolean');
     });
 
-    it('returns false when not connected', async () => {
+    it('toggles mute state when not connected (pre-set)', async () => {
       const result = await webrtcService.toggleMute();
-      expect(result).toBe(false);
+      expect(result).toBe(true); // was unmuted → now muted
+      expect(useVoiceStore.getState().muted).toBe(true);
     });
 
     it('returns false when pushToTalk is enabled', async () => {

--- a/client/src/services/webrtc/WebRTCService.ts
+++ b/client/src/services/webrtc/WebRTCService.ts
@@ -96,7 +96,8 @@ class WebRTCService {
         console.log('[Voice] Using TURN relay (no IP leaks)');
       }
     } catch {
-      console.log('[Voice] TURN not available, using STUN');
+      // TURN credentials endpoint not available — expected when no TURN
+      // server is configured. Voice falls back to STUN (peer-to-peer).
     }
 
     // Create peer connection

--- a/client/src/services/webrtc/WebRTCService.ts
+++ b/client/src/services/webrtc/WebRTCService.ts
@@ -443,7 +443,14 @@ class WebRTCService {
   async toggleMute(): Promise<boolean> {
     // PTT mode: toggleMute is a no-op
     if (useAudioSettingsStore.getState().pushToTalk) return false;
-    if (!this.pc) return false;
+
+    // Allow toggling mute even when not in a voice channel (pre-set state)
+    if (!this.pc) {
+      const store = useVoiceStore.getState();
+      const newMuted = !store.muted;
+      store.setMuted(newMuted);
+      return newMuted;
+    }
 
     const store = useVoiceStore.getState();
     const wasMuted = store.muted;
@@ -510,6 +517,14 @@ class WebRTCService {
   async toggleDeafen(): Promise<boolean> {
     const store = useVoiceStore.getState();
     const deafened = !store.deafened;
+
+    // Allow toggling deafen even when not in a voice channel (pre-set state)
+    if (!this.pc) {
+      store.setDeafened(deafened);
+      if (deafened) store.setMuted(true);
+      return deafened;
+    }
+
     // Mute all remote audio
     for (const stream of this.remoteStreams.values()) {
       for (const track of stream.getAudioTracks()) {


### PR DESCRIPTION
## Summary

Collection of UI fixes found during manual testing:

- **Resize handle**: enforce min 240px / max 400px on channel sidebar, sync left-panels width dynamically
- **Search bar**: swap order with member toggle, align width to member sidebar using design token vars, use `flex: 1` sizing in actions container
- **Mute/deafen**: allow toggle when not in a voice channel (pre-set state for when joining)
- **TURN credentials**: silence noisy 404 console error (endpoint doesn't exist, STUN fallback is expected)

## Test Plan
- [x] Resize handle respects min/max bounds
- [x] Search bar aligns with member list column
- [x] Member toggle appears before search
- [x] Mute button works outside voice channel
- [ ] Manual: verify no visual regression