### PR TITLE
feat: UI overhaul round 1 — refined dark luxury

### DIFF
--- a/client/src/components/ChannelList/ChannelList.css
+++ b/client/src/components/ChannelList/ChannelList.css
@@ -247,7 +247,8 @@
   opacity: 0.7;
 }
 
-.voice-user-icon.screen-sharing {
+.voice-user-icon.screen-sharing,
+.voice-user-icon.webcam-sharing {
   color: var(--status-online);
   opacity: 1;
 }

--- a/client/src/components/ChannelList/ChannelList.css
+++ b/client/src/components/ChannelList/ChannelList.css
@@ -66,7 +66,7 @@
   display: flex;
   align-items: center;
   padding: var(--spacing-sm);
-  margin: 2px var(--spacing-sm);
+  margin: var(--spacing-xs) var(--spacing-sm);
   border: none;
   border-radius: var(--radius-md);
   background: none;

--- a/client/src/components/ChannelList/ChannelList.css
+++ b/client/src/components/ChannelList/ChannelList.css
@@ -78,6 +78,7 @@
   font-weight: var(--font-weight-medium);
   gap: 6px;
   position: relative;
+  transition: background-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
 }
 
 .channel-item::before {
@@ -261,7 +262,7 @@
   height: 16px;
   padding: 0 var(--spacing-xs);
   border-radius: var(--radius-full);
-  background: var(--brand-500);
+  background: var(--accent);
   color: #fff;
   font-size: var(--font-size-micro);
   font-weight: var(--font-weight-semibold);

--- a/client/src/components/ChannelList/ChannelList.css
+++ b/client/src/components/ChannelList/ChannelList.css
@@ -65,18 +65,18 @@
 .channel-item {
   display: flex;
   align-items: center;
-  padding: 6px var(--spacing-sm);
-  margin: 1px var(--spacing-sm);
+  padding: var(--spacing-sm);
+  margin: 2px var(--spacing-sm);
   border: none;
   border-radius: var(--radius-md);
   background: none;
   font-family: inherit;
   text-align: left;
-  width: calc(100% - 16px);
+  width: calc(100% - var(--spacing-lg));
   color: var(--interactive-normal);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
-  gap: 6px;
+  gap: var(--spacing-sm);
   position: relative;
   transition: background-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
 }

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -175,7 +175,7 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                           <span className="voice-user-name">{peer.username}</span>
                           {isMuted && <MicrophoneMute width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
                           {isDeafened && <HeadsetWarning width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
-                          {isWebcamSharing && <VideoCamera width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
+                          {isWebcamSharing && <VideoCamera width={14} height={14} strokeWidth={2} className="voice-user-icon webcam-sharing" />}
                           {isScreenSharing && <AppWindow width={14} height={14} strokeWidth={2} className="voice-user-icon screen-sharing" />}
                         </div>
                       );

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -119,7 +119,7 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                 speaking: false,
                 voiceLevel: 0,
               };
-              voicePeerList = [localEntry, ...voicePeerValues];
+              voicePeerList = [localEntry, ...voicePeerValues.filter(p => p.user_id !== currentUserId)];
             } else if (isVoice) {
               voicePeerList = voiceOccupants[ch.id] ?? [];
             } else {

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -118,7 +118,7 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                 speaking: false,
                 voiceLevel: 0,
               };
-              voicePeerList = [localUser, ...voicePeerValues];
+              voicePeerList = [localUser, ...voicePeerValues.filter(p => p.user_id !== currentUserId)];
             } else if (isVoice) {
               voicePeerList = voiceOccupants[ch.id] ?? [];
             } else {

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -107,9 +107,23 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
             // Show rich peer data if connected, otherwise show occupants from server
             const voicePeerValues = Object.values(voicePeers);
             let voicePeerList: typeof voicePeerValues;
-            if (isVoiceConnected) voicePeerList = voicePeerValues;
-            else if (isVoice) voicePeerList = voiceOccupants[ch.id] ?? [];
-            else voicePeerList = [];
+            if (isVoiceConnected) {
+              // Add local user to the peer list (WebRTC peers are remote only)
+              const localUser = {
+                user_id: currentUserId,
+                username: teams.get(authActiveTeamId ?? '')?.user?.username ?? '',
+                muted: localMuted,
+                deafened: localDeafened,
+                screen_sharing: localScreenSharing,
+                speaking: false,
+                voiceLevel: 0,
+              };
+              voicePeerList = [localUser, ...voicePeerValues];
+            } else if (isVoice) {
+              voicePeerList = voiceOccupants[ch.id] ?? [];
+            } else {
+              voicePeerList = [];
+            }
 
             const unreadCount = unreadCounts[ch.id] ?? 0;
             const hasUnread = !isVoice && unreadCount > 0;

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -108,17 +108,13 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
             const voicePeerValues = Object.values(voicePeers);
             let voicePeerList: typeof voicePeerValues;
             if (isVoiceConnected) {
-              // Add local user to the peer list (WebRTC peers are remote only)
-              const localUser = {
-                user_id: currentUserId,
-                username: teams.get(authActiveTeamId ?? '')?.user?.username ?? '',
-                muted: localMuted,
-                deafened: localDeafened,
-                screen_sharing: localScreenSharing,
-                speaking: false,
-                voiceLevel: 0,
-              };
-              voicePeerList = [localUser, ...voicePeerValues.filter(p => p.user_id !== currentUserId)];
+              // Merge local mute state into occupant data (which includes self)
+              const occupants = voiceOccupants[ch.id] ?? [];
+              voicePeerList = occupants.map(p =>
+                p.user_id === currentUserId
+                  ? { ...p, muted: localMuted, deafened: localDeafened, screen_sharing: localScreenSharing }
+                  : p,
+              );
             } else if (isVoice) {
               voicePeerList = voiceOccupants[ch.id] ?? [];
             } else {

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SoundHigh, Plus, MicrophoneMute, HeadsetWarning, AppWindow } from 'iconoir-react';
+import { SoundHigh, Plus, MicrophoneMute, HeadsetWarning, AppWindow, VideoCamera } from 'iconoir-react';
 import { useTeamStore, type Channel } from '../../stores/teamStore';
 import { useVoiceStore } from '../../stores/voiceStore';
 import { useUnreadStore } from '../../stores/unreadStore';
@@ -22,7 +22,7 @@ interface Props {
 export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
   const { t } = useTranslation();
   const { channels, activeTeamId, activeChannelId, setActiveChannel, removeChannel } = useTeamStore();
-  const { currentChannelId: voiceChannelId, connected: voiceConnected, peers: voicePeers, voiceOccupants, joinChannel: voiceJoin, muted: localMuted, deafened: localDeafened, screenSharing: localScreenSharing } = useVoiceStore();
+  const { currentChannelId: voiceChannelId, connected: voiceConnected, peers: voicePeers, voiceOccupants, joinChannel: voiceJoin, muted: localMuted, deafened: localDeafened, screenSharing: localScreenSharing, webcamSharing: localWebcamSharing } = useVoiceStore();
   const { counts: unreadCounts } = useUnreadStore();
   const authTeams = useAuthStore((s) => s.teams);
   const currentUserId = (activeTeamId ? authTeams.get(activeTeamId)?.user?.id : '') ?? '';
@@ -162,6 +162,7 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                       const isMuted = isLocal ? localMuted : peer.muted;
                       const isDeafened = isLocal ? localDeafened : peer.deafened;
                       const isScreenSharing = isLocal ? localScreenSharing : peer.screen_sharing;
+                      const isWebcamSharing = isLocal ? localWebcamSharing : false;
                       return (
                         <div
                           key={peer.user_id}
@@ -174,6 +175,7 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                           <span className="voice-user-name">{peer.username}</span>
                           {isMuted && <MicrophoneMute width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
                           {isDeafened && <HeadsetWarning width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
+                          {isWebcamSharing && <VideoCamera width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
                           {isScreenSharing && <AppWindow width={14} height={14} strokeWidth={2} className="voice-user-icon screen-sharing" />}
                         </div>
                       );

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -24,8 +24,8 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
   const { channels, activeTeamId, activeChannelId, setActiveChannel, removeChannel } = useTeamStore();
   const { currentChannelId: voiceChannelId, connected: voiceConnected, peers: voicePeers, voiceOccupants, joinChannel: voiceJoin, muted: localMuted, deafened: localDeafened, screenSharing: localScreenSharing } = useVoiceStore();
   const { counts: unreadCounts } = useUnreadStore();
-  const { teams, activeTeamId: authActiveTeamId } = useAuthStore();
-  const currentUserId = (authActiveTeamId ? teams.get(authActiveTeamId)?.user?.id : '') ?? '';
+  const authTeams = useAuthStore((s) => s.teams);
+  const currentUserId = (activeTeamId ? authTeams.get(activeTeamId)?.user?.id : '') ?? '';
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
   const [editingChannel, setEditingChannel] = useState<Channel | null>(null);
@@ -108,13 +108,18 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
             const voicePeerValues = Object.values(voicePeers);
             let voicePeerList: typeof voicePeerValues;
             if (isVoiceConnected) {
-              // Merge local mute state into occupant data (which includes self)
-              const occupants = voiceOccupants[ch.id] ?? [];
-              voicePeerList = occupants.map(p =>
-                p.user_id === currentUserId
-                  ? { ...p, muted: localMuted, deafened: localDeafened, screen_sharing: localScreenSharing }
-                  : p,
-              );
+              // WebRTC peers = remote users only. Add local user with store state.
+              const localUsername = (activeTeamId ? authTeams.get(activeTeamId)?.user?.username : '') ?? 'You';
+              const localEntry = {
+                user_id: currentUserId,
+                username: localUsername,
+                muted: localMuted,
+                deafened: localDeafened,
+                screen_sharing: localScreenSharing,
+                speaking: false,
+                voiceLevel: 0,
+              };
+              voicePeerList = [localEntry, ...voicePeerValues];
             } else if (isVoice) {
               voicePeerList = voiceOccupants[ch.id] ?? [];
             } else {

--- a/client/src/components/ChannelList/ChannelList.tsx
+++ b/client/src/components/ChannelList/ChannelList.tsx
@@ -4,6 +4,7 @@ import { SoundHigh, Plus, MicrophoneMute, HeadsetWarning, AppWindow } from 'icon
 import { useTeamStore, type Channel } from '../../stores/teamStore';
 import { useVoiceStore } from '../../stores/voiceStore';
 import { useUnreadStore } from '../../stores/unreadStore';
+import { useAuthStore } from '../../stores/authStore';
 import { api } from '../../services/api';
 import EditChannel from '../EditChannel/EditChannel';
 import './ChannelList.css';
@@ -21,8 +22,10 @@ interface Props {
 export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
   const { t } = useTranslation();
   const { channels, activeTeamId, activeChannelId, setActiveChannel, removeChannel } = useTeamStore();
-  const { currentChannelId: voiceChannelId, connected: voiceConnected, peers: voicePeers, voiceOccupants, joinChannel: voiceJoin } = useVoiceStore();
+  const { currentChannelId: voiceChannelId, connected: voiceConnected, peers: voicePeers, voiceOccupants, joinChannel: voiceJoin, muted: localMuted, deafened: localDeafened, screenSharing: localScreenSharing } = useVoiceStore();
   const { counts: unreadCounts } = useUnreadStore();
+  const { teams, activeTeamId: authActiveTeamId } = useAuthStore();
+  const currentUserId = (authActiveTeamId ? teams.get(authActiveTeamId)?.user?.id : '') ?? '';
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
   const [editingChannel, setEditingChannel] = useState<Channel | null>(null);
@@ -139,21 +142,27 @@ export default function ChannelList({ onCreateChannel }: Readonly<Props>) {
                 </button>
                 {voicePeerList.length > 0 && (
                   <div className="voice-channel-users">
-                    {voicePeerList.map((peer) => (
-                      <div
-                        key={peer.user_id}
-                        className={`voice-channel-user ${peer.speaking ? 'speaking' : ''}`}
-                        style={{ '--voice-level': peer.voiceLevel ?? 0 } as React.CSSProperties}
-                      >
-                        <span className="voice-user-avatar">
-                          {peer.username.slice(0, 1).toUpperCase()}
-                        </span>
-                        <span className="voice-user-name">{peer.username}</span>
-                        {peer.muted && <MicrophoneMute width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
-                        {peer.deafened && <HeadsetWarning width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
-                        {peer.screen_sharing && <AppWindow width={14} height={14} strokeWidth={2} className="voice-user-icon screen-sharing" />}
-                      </div>
-                    ))}
+                    {voicePeerList.map((peer) => {
+                      const isLocal = peer.user_id === currentUserId;
+                      const isMuted = isLocal ? localMuted : peer.muted;
+                      const isDeafened = isLocal ? localDeafened : peer.deafened;
+                      const isScreenSharing = isLocal ? localScreenSharing : peer.screen_sharing;
+                      return (
+                        <div
+                          key={peer.user_id}
+                          className={`voice-channel-user ${peer.speaking ? 'speaking' : ''}`}
+                          style={{ '--voice-level': peer.voiceLevel ?? 0 } as React.CSSProperties}
+                        >
+                          <span className="voice-user-avatar">
+                            {peer.username.slice(0, 1).toUpperCase()}
+                          </span>
+                          <span className="voice-user-name">{peer.username}</span>
+                          {isMuted && <MicrophoneMute width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
+                          {isDeafened && <HeadsetWarning width={14} height={14} strokeWidth={2} className="voice-user-icon" />}
+                          {isScreenSharing && <AppWindow width={14} height={14} strokeWidth={2} className="voice-user-icon screen-sharing" />}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/client/src/components/MemberList/MemberList.css
+++ b/client/src/components/MemberList/MemberList.css
@@ -1,13 +1,11 @@
 .member-list {
   width: var(--member-sidebar-width);
-  background: var(--glass-bg-secondary);
-  -webkit-backdrop-filter: blur(var(--glass-blur));
-  backdrop-filter: blur(var(--glass-blur));
+  background: var(--bg-secondary);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   padding: var(--spacing-xl) 0 var(--spacing-sm);
-  border-left: 1px solid var(--glass-border);
+  box-shadow: -1px 0 0 var(--divider);
 }
 
 .member-list-header {

--- a/client/src/components/MemberList/MemberList.css
+++ b/client/src/components/MemberList/MemberList.css
@@ -39,10 +39,10 @@
   margin: 1px 8px 0;
   gap: var(--spacing-md);
   cursor: pointer;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   height: 42px;
   box-sizing: border-box;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-fast) var(--ease-out);
 }
 
 .member-item:hover {
@@ -50,7 +50,7 @@
 }
 
 .member-item.offline {
-  opacity: 0.4;
+  opacity: 0.55;
 }
 
 .member-avatar {

--- a/client/src/components/MessageInput/MessageInput.css
+++ b/client/src/components/MessageInput/MessageInput.css
@@ -7,6 +7,17 @@
   z-index: 10;
 }
 
+.message-input-wrapper::before {
+  content: '';
+  position: absolute;
+  top: calc(-1 * var(--spacing-2xl));
+  left: 0;
+  right: 0;
+  height: var(--spacing-2xl);
+  background: linear-gradient(to bottom, transparent, var(--bg-primary));
+  pointer-events: none;
+}
+
 .message-input-composer {
   background: var(--glass-bg-secondary);
   -webkit-backdrop-filter: blur(var(--glass-blur-heavy));

--- a/client/src/components/MessageInput/MessageInput.css
+++ b/client/src/components/MessageInput/MessageInput.css
@@ -5,15 +5,23 @@
   position: relative;
   padding: 0;
   z-index: 10;
+  margin-top: calc(-1 * var(--spacing-2xl));
+  pointer-events: none;
+}
+
+.message-input-wrapper > * {
+  pointer-events: auto;
 }
 
 .message-input-composer {
-  background: var(--bg-secondary);
+  background: var(--glass-bg-secondary);
+  -webkit-backdrop-filter: blur(var(--glass-blur-heavy));
+  backdrop-filter: blur(var(--glass-blur-heavy));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
-  box-shadow: 0 -2px 12px var(--overlay-light);
+  box-shadow: 0 -4px 20px var(--overlay-dark);
   margin: 0 var(--spacing-lg) var(--spacing-lg);
 }
 

--- a/client/src/components/MessageInput/MessageInput.css
+++ b/client/src/components/MessageInput/MessageInput.css
@@ -12,9 +12,10 @@
   -webkit-backdrop-filter: blur(var(--glass-blur-light));
   backdrop-filter: blur(var(--glass-blur-light));
   border: 1px solid var(--glass-border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 -2px 12px var(--overlay-light);
 }
 
 .message-input-composer:focus-within {
@@ -133,6 +134,7 @@
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
   font-family: inherit;
+  transition: color var(--duration-fast) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
 }
 
 .toolbar-btn:hover {

--- a/client/src/components/MessageInput/MessageInput.css
+++ b/client/src/components/MessageInput/MessageInput.css
@@ -5,12 +5,6 @@
   position: relative;
   padding: 0;
   z-index: 10;
-  margin-top: calc(-1 * var(--spacing-2xl));
-  pointer-events: none;
-}
-
-.message-input-wrapper > * {
-  pointer-events: auto;
 }
 
 .message-input-composer {

--- a/client/src/components/MessageInput/MessageInput.css
+++ b/client/src/components/MessageInput/MessageInput.css
@@ -3,19 +3,18 @@
 .message-input-wrapper {
   flex-shrink: 0;
   position: relative;
-  padding: 0 var(--spacing-lg) var(--spacing-lg);
+  padding: 0;
   z-index: 10;
 }
 
 .message-input-composer {
-  background: var(--glass-bg-primary);
-  -webkit-backdrop-filter: blur(var(--glass-blur-light));
-  backdrop-filter: blur(var(--glass-blur-light));
+  background: var(--bg-secondary);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-shadow: 0 -2px 12px var(--overlay-light);
+  margin: 0 var(--spacing-lg) var(--spacing-lg);
 }
 
 .message-input-composer:focus-within {
@@ -79,7 +78,7 @@
   border: none;
   box-sizing: border-box;
   color: var(--text-normal);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-base);
   font-family: inherit;
   padding: 0;
   margin: 0;
@@ -108,7 +107,7 @@
 .toolbar-group {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--spacing-xs);
 }
 
 .toolbar-divider {
@@ -134,6 +133,7 @@
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
   font-family: inherit;
+  border-radius: var(--radius-md);
   transition: color var(--duration-fast) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
 }
 
@@ -171,18 +171,20 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   flex-shrink: 0;
-  transition: color 0.15s ease;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
 .toolbar-send-btn.has-content {
-  color: var(--brand-500);
+  background: var(--brand-500);
+  color: white;
   cursor: pointer;
 }
 
 .toolbar-send-btn.has-content:hover {
-  color: var(--brand-560);
+  background: var(--brand-560);
+  color: white;
 }
 
 .toolbar-send-btn svg {
@@ -304,8 +306,8 @@
 
 /* ===== Responsive ===== */
 @media (max-width: 767px) {
-  .message-input-wrapper {
-    padding: 0 var(--spacing-sm) var(--spacing-sm);
+  .message-input-composer {
+    margin: 0 var(--spacing-sm) var(--spacing-sm);
   }
 
   .message-input-textarea {

--- a/client/src/components/MessageList/MessageList.css
+++ b/client/src/components/MessageList/MessageList.css
@@ -1,6 +1,6 @@
 .message-list {
   flex: 1;
-  padding: var(--spacing-sm) 0 0;
+  padding: var(--spacing-sm) 0 var(--spacing-2xl);
 }
 
 .message-list-loading {

--- a/client/src/components/MessageList/MessageList.css
+++ b/client/src/components/MessageList/MessageList.css
@@ -134,6 +134,7 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
   line-height: 1.5;
+  white-space: pre-wrap;
 }
 
 /* Markdown content styling */

--- a/client/src/components/MessageList/MessageList.css
+++ b/client/src/components/MessageList/MessageList.css
@@ -12,13 +12,13 @@
 
 .message-list-beginning {
   text-align: center;
-  padding: var(--spacing-lg);
+  padding: var(--spacing-2xl) var(--spacing-lg) var(--spacing-xl);
   color: var(--text-muted);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-xl);
   font-family: var(--font-display);
   font-weight: var(--font-weight-semibold);
-  border-bottom: 1px solid var(--divider);
-  margin-bottom: var(--spacing-sm);
+  background: linear-gradient(180deg, transparent, var(--white-overlay-subtle) 50%, transparent);
+  margin-bottom: var(--spacing-lg);
 }
 
 /* System messages */
@@ -40,12 +40,12 @@
 .message-group {
   display: flex;
   padding: 2px 48px 2px var(--spacing-lg);
-  margin-top: 1.0625rem;
+  margin-top: var(--spacing-xl);
   position: relative;
 }
 
 .message-group:first-child {
-  margin-top: 1rem;
+  margin-top: var(--spacing-lg);
 }
 
 /* hover highlight moved to .message-item level for per-message actions */
@@ -85,13 +85,13 @@
 .message-group-header {
   display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: var(--spacing-sm);
   margin-bottom: 0.125rem;
   line-height: 1.375rem;
 }
 
 .message-username {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   color: var(--header-primary);
   cursor: pointer;
@@ -103,9 +103,10 @@
 }
 
 .message-timestamp {
-  font-size: 0.75rem;
+  font-size: var(--font-size-micro);
   color: var(--text-muted);
   font-weight: var(--font-weight-medium);
+  opacity: 0.7;
 }
 
 /* Individual messages */
@@ -128,11 +129,11 @@
 }
 
 .message-content {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--text-normal);
   word-wrap: break-word;
   overflow-wrap: break-word;
-  line-height: 1.375rem;
+  line-height: 1.5;
 }
 
 /* Markdown content styling */
@@ -149,15 +150,15 @@
   background: var(--bg-tertiary);
   padding: 0.2em 0.4em;
   border-radius: var(--radius-sm);
-  font-size: 0.875em;
+  font-size: 0.85em;
   font-family: var(--font-mono);
 }
 
 .message-content pre {
   background: var(--bg-tertiary);
   border: 1px solid var(--divider);
-  border-radius: var(--radius-md);
-  padding: 0.5em;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md);
   margin: 6px 0 6px 0;
   overflow-x: auto;
   max-width: 90%;
@@ -203,7 +204,7 @@
 }
 
 .message-edited {
-  font-size: 0.625rem;
+  font-size: var(--font-size-micro);
   color: var(--text-muted);
   margin-left: var(--spacing-xs);
   font-weight: var(--font-weight-normal);
@@ -213,15 +214,15 @@
 .message-actions {
   display: none;
   position: absolute;
-  top: -16px;
-  right: -32px;
+  top: calc(-1 * var(--spacing-lg));
+  right: var(--spacing-sm);
   background: var(--glass-bg-floating);
   -webkit-backdrop-filter: blur(var(--glass-blur-light));
   backdrop-filter: blur(var(--glass-blur-light));
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
-  padding: 2px;
-  gap: 0;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xs);
+  gap: 2px;
   z-index: 1;
   box-shadow: 0 4px 12px var(--overlay-dark);
 }
@@ -232,8 +233,8 @@
 }
 
 .message-item:hover {
-  background: var(--bg-modifier-hover);
-  border-radius: var(--radius-sm);
+  background: var(--white-overlay-subtle);
+  border-radius: var(--radius-md);
   margin: 0 calc(-1 * var(--spacing-xs));
   padding-left: var(--spacing-xs);
   padding-right: var(--spacing-xs);

--- a/client/src/components/MessageList/MessageList.css
+++ b/client/src/components/MessageList/MessageList.css
@@ -1,6 +1,6 @@
 .message-list {
   flex: 1;
-  padding: var(--spacing-sm) 0 var(--spacing-2xl);
+  padding: var(--spacing-sm) 0 0;
 }
 
 .message-list-loading {

--- a/client/src/components/MessageList/MessageList.css
+++ b/client/src/components/MessageList/MessageList.css
@@ -114,6 +114,7 @@
   padding: 0.125rem 0;
   line-height: 1.375rem;
   min-height: 1.375rem;
+  transition: background-color var(--duration-fast) var(--ease-out);
 }
 
 .message-item.deleted {
@@ -222,7 +223,7 @@
   padding: 2px;
   gap: 0;
   z-index: 1;
-  box-shadow: 0 2px 8px 0 var(--overlay-light);
+  box-shadow: 0 4px 12px var(--overlay-dark);
 }
 
 .message-item:hover .message-actions,

--- a/client/src/components/MessageList/MessageList.tsx
+++ b/client/src/components/MessageList/MessageList.tsx
@@ -101,6 +101,7 @@ export default function MessageList({
       followOutput={() => 'smooth'}
       startReached={handleStartReached}
       components={{
+        Footer: () => <div style={{ height: 'var(--spacing-2xl)', minHeight: 32 }} />,
         Header: () => (
           <>
             {isLoading && <MessageSkeleton count={5} />}

--- a/client/src/components/TeamSidebar/TeamSidebar.css
+++ b/client/src/components/TeamSidebar/TeamSidebar.css
@@ -70,18 +70,18 @@
   font-size: 18px;
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  transition: border-radius 0.2s ease, background-color 0.2s ease;
+  transition: border-radius var(--duration-normal) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
   position: relative;
 }
 
 .team-icon:hover {
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   background-color: var(--brand-500);
   color: white;
 }
 
 .team-icon.active {
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   background-color: var(--brand-500);
   color: white;
 }

--- a/client/src/components/TeamSidebar/TeamSidebar.css
+++ b/client/src/components/TeamSidebar/TeamSidebar.css
@@ -1,8 +1,6 @@
 .team-sidebar {
   width: var(--team-sidebar-width);
-  background: var(--glass-bg-tertiary);
-  -webkit-backdrop-filter: blur(var(--glass-blur-heavy));
-  backdrop-filter: blur(var(--glass-blur-heavy));
+  background: var(--bg-tertiary);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/client/src/components/UserPanel/UserPanel.css
+++ b/client/src/components/UserPanel/UserPanel.css
@@ -4,6 +4,7 @@
   padding: 0 var(--spacing-md);
   height: var(--user-panel-height);
   gap: var(--spacing-sm);
+  border-top: 1px solid var(--glass-border-light);
 }
 
 .user-panel-avatar {
@@ -78,6 +79,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: color var(--duration-fast) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
 }
 
 .user-panel-btn:hover {

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -79,7 +79,6 @@
   gap: var(--spacing-sm);
   transition: box-shadow var(--duration-fast) var(--ease-out);
   position: relative;
-  min-height: 160px;
   overflow: hidden;
 }
 
@@ -236,15 +235,9 @@
   margin-top: auto;
 }
 
-/* When webcam active: gradient overlay for text readability */
-.voice-tile:has(.voice-tile-webcam-fill) {
-  padding: 0;
-}
-
+/* When webcam active: name/icons overlay on top of video */
 .voice-tile:has(.voice-tile-webcam-fill) .voice-tile-overlay {
-  width: 100%;
-  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, transparent 100%);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
 }
 
 /* Fullscreen screen share overlay */

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -80,6 +80,15 @@
   transition: box-shadow var(--duration-fast) var(--ease-out);
   position: relative;
   overflow: hidden;
+  min-width: 0;
+}
+
+/* Webcam tile: invisible spacer maintains avatar-equivalent height */
+.voice-tile:has(.voice-tile-webcam-fill)::before {
+  content: '';
+  width: 64px;
+  height: 64px;
+  flex-shrink: 0;
 }
 
 .voice-tile.speaking {
@@ -213,7 +222,7 @@
 
 /* Webcam replaces avatar — circular crop */
 /* Webcam replaces avatar — same tile layout */
-/* Webcam fills entire tile */
+/* Webcam fills entire tile — absolute so it doesn't affect tile size */
 .voice-tile-webcam-fill {
   position: absolute;
   inset: 0;
@@ -223,6 +232,7 @@
   background: var(--bg-tertiary);
   transform: scaleX(-1);
   border-radius: inherit;
+  z-index: 0;
 }
 
 .voice-tile-overlay {

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -70,14 +70,17 @@
 
 .voice-tile {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   padding: var(--spacing-xl) var(--spacing-lg);
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: var(--spacing-sm);
-  transition: box-shadow 0.15s ease;
+  transition: box-shadow var(--duration-fast) var(--ease-out);
   position: relative;
+  min-height: 160px;
+  overflow: hidden;
 }
 
 .voice-tile.speaking {
@@ -211,17 +214,37 @@
 
 /* Webcam replaces avatar — circular crop */
 /* Webcam replaces avatar — same tile layout */
+/* Webcam fills entire tile */
 .voice-tile-webcam-fill {
-  width: 64px;
-  height: 64px;
-  border-radius: var(--radius-full);
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   background: var(--bg-tertiary);
   transform: scaleX(-1);
+  border-radius: inherit;
 }
 
 .voice-tile-overlay {
-  display: contents;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: auto;
+}
+
+/* When webcam active: gradient overlay for text readability */
+.voice-tile:has(.voice-tile-webcam-fill) {
+  padding: 0;
+}
+
+.voice-tile:has(.voice-tile-webcam-fill) .voice-tile-overlay {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, transparent 100%);
 }
 
 /* Fullscreen screen share overlay */

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -212,12 +212,12 @@
 /* Webcam replaces avatar — circular crop */
 /* Webcam replaces avatar — same tile layout */
 .voice-tile-webcam-fill {
-  width: 100%;
-  border-radius: var(--radius-md);
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-full);
   object-fit: cover;
   background: var(--bg-tertiary);
   transform: scaleX(-1);
-  aspect-ratio: 4 / 3;
 }
 
 .voice-tile-overlay {

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -214,8 +214,6 @@
 .voice-tile.has-webcam {
   padding: 0;
   overflow: hidden;
-  min-height: 180px;
-  aspect-ratio: 4 / 3;
 }
 
 .voice-tile-webcam-fill {

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -210,18 +210,48 @@
 }
 
 /* Webcam replaces avatar — circular crop */
-.voice-tile-webcam-avatar {
-  width: 64px;
-  height: 64px;
-  border-radius: var(--radius-full);
+/* Webcam fills the entire tile */
+.voice-tile.has-webcam {
+  padding: 0;
+  overflow: hidden;
+  min-height: 180px;
+  aspect-ratio: 4 / 3;
+}
+
+.voice-tile-webcam-fill {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   background: var(--bg-tertiary);
   transform: scaleX(-1);
-  box-shadow: 0 0 0 2px var(--bg-modifier-accent, var(--white-overlay-light));
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
 }
 
-.voice-tile.speaking .voice-tile-webcam-avatar {
-  box-shadow: 0 0 0 2px var(--status-online);
+.voice-tile-overlay {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: auto;
+  width: 100%;
+  padding: var(--spacing-sm);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+.voice-tile.has-webcam .voice-tile-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.voice-tile.speaking .voice-tile-webcam-fill {
+  box-shadow: inset 0 0 0 2px var(--status-online);
 }
 
 /* Fullscreen screen share overlay */

--- a/client/src/components/VoiceChannel/VoiceChannel.css
+++ b/client/src/components/VoiceChannel/VoiceChannel.css
@@ -210,46 +210,18 @@
 }
 
 /* Webcam replaces avatar — circular crop */
-/* Webcam fills the entire tile */
-.voice-tile.has-webcam {
-  padding: 0;
-  overflow: hidden;
-}
-
+/* Webcam replaces avatar — same tile layout */
 .voice-tile-webcam-fill {
   width: 100%;
-  height: 100%;
+  border-radius: var(--radius-md);
   object-fit: cover;
   background: var(--bg-tertiary);
   transform: scaleX(-1);
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
+  aspect-ratio: 4 / 3;
 }
 
 .voice-tile-overlay {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-xs);
-  margin-top: auto;
-  width: 100%;
-  padding: var(--spacing-sm);
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-}
-
-.voice-tile.has-webcam .voice-tile-overlay {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-.voice-tile.speaking .voice-tile-webcam-fill {
-  box-shadow: inset 0 0 0 2px var(--status-online);
+  display: contents;
 }
 
 /* Fullscreen screen share overlay */

--- a/client/src/components/VoiceChannel/VoiceChannel.tsx
+++ b/client/src/components/VoiceChannel/VoiceChannel.tsx
@@ -170,23 +170,25 @@ export default function VoiceChannel({ channel }: Readonly<Props>) {
                 return (
                   <div
                     key={peer.user_id}
-                    className={`voice-tile ${peer.speaking ? 'speaking' : ''}`}
+                    className={`voice-tile ${peer.speaking ? 'speaking' : ''} ${isSharingWebcam && webcamStream ? 'has-webcam' : ''}`}
                     style={{ '--voice-level': peer.voiceLevel ?? 0 } as React.CSSProperties}
                   >
                     {isSharingWebcam && webcamStream ? (
-                      <VideoPreview stream={webcamStream} className="voice-tile-webcam-avatar" />
+                      <VideoPreview stream={webcamStream} className="voice-tile-webcam-fill" />
                     ) : (
                       <div className={`voice-tile-avatar ${peer.speaking ? 'speaking-ring' : ''}`}>
                         {peer.username.slice(0, 2).toUpperCase()}
                       </div>
                     )}
-                    <div className="voice-tile-name truncate">{peer.username}</div>
-                    <div className="voice-tile-icons">
-                      {peer.muted && <span title={t('voice.mute')}><MicrophoneMute width={16} height={16} strokeWidth={2} /></span>}
-                      {peer.deafened && <span title={t('voice.deafen')}><HeadsetWarning width={16} height={16} strokeWidth={2} /></span>}
-                      {peer.screen_sharing && <span title="Sharing screen"><AppWindow width={16} height={16} strokeWidth={2} /></span>}
-                      {isSharingWebcam && <span title="Camera on"><VideoCamera width={16} height={16} strokeWidth={2} /></span>}
-                      {peer.speaking && <span className="voice-tile-speaking-label">{t('voice.speaking')}</span>}
+                    <div className="voice-tile-overlay">
+                      <div className="voice-tile-name truncate">{peer.username}</div>
+                      <div className="voice-tile-icons">
+                        {peer.muted && <span title={t('voice.mute')}><MicrophoneMute width={16} height={16} strokeWidth={2} /></span>}
+                        {peer.deafened && <span title={t('voice.deafen')}><HeadsetWarning width={16} height={16} strokeWidth={2} /></span>}
+                        {peer.screen_sharing && <span title="Sharing screen"><AppWindow width={16} height={16} strokeWidth={2} /></span>}
+                        {isSharingWebcam && <span title="Camera on"><VideoCamera width={16} height={16} strokeWidth={2} /></span>}
+                        {peer.speaking && <span className="voice-tile-speaking-label">{t('voice.speaking')}</span>}
+                      </div>
                     </div>
                   </div>
                 );

--- a/client/src/components/VoiceControls/VoiceControls.css
+++ b/client/src/components/VoiceControls/VoiceControls.css
@@ -2,6 +2,7 @@
   padding: 10px 12px 6px 12px;
   overflow: visible;
   animation: voice-slide-in 0.25s ease-out;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 
 .voice-controls + .user-panel {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -42,7 +42,7 @@ h1 {
 }
 
 button {
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
@@ -51,14 +51,16 @@ button {
   background-color: var(--bg-tertiary);
   color: var(--text-primary);
   cursor: pointer;
-  transition: background-color 0.15s ease, border-color 0.15s ease;
+  transition: background-color var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast) var(--ease-out);
 }
 button:hover {
   border-color: var(--bg-accent);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid var(--brand-500);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 /* Global select styling */
@@ -120,4 +122,11 @@ select option {
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thin-thumb) var(--scrollbar-thin-track);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -59,7 +59,7 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 2px solid var(--brand-500);
-  outline-offset: -2px;
+  outline-offset: calc(-1 * var(--spacing-xs));
 }
 
 /* Global select styling */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -59,8 +59,7 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 2px solid var(--brand-500);
-  outline-offset: 2px;
-  border-radius: var(--radius-sm);
+  outline-offset: -2px;
 }
 
 /* Global select styling */

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -21,7 +21,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: var(--bg-primary);
+  background: var(--bg-tertiary);
 }
 
 /* When TitleBar is present (Tauri), offset content below it.
@@ -48,18 +48,14 @@
 }
 
 .left-panels-bottom {
-  background: var(--bg-tertiary);
+  background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
   flex-shrink: 0;
-  border-top: 1px solid var(--divider);
 }
 
 /* Channel sidebar (second column) */
 .channel-sidebar {
   width: var(--channel-sidebar-width);
-  background: var(--glass-bg-secondary);
-  -webkit-backdrop-filter: blur(var(--glass-blur));
-  backdrop-filter: blur(var(--glass-blur));
-  border-right: 1px solid var(--glass-border);
+  background: var(--bg-secondary);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -93,6 +89,7 @@
   min-height: 0;
   overflow: hidden;
   background: var(--bg-primary);
+  box-shadow: -1px 0 0 var(--divider);
 }
 
 /* Header bar */
@@ -102,14 +99,11 @@
   display: flex;
   align-items: center;
   padding: 0 var(--spacing-lg);
-  background: var(--glass-bg-primary);
-  -webkit-backdrop-filter: blur(var(--glass-blur-light));
-  backdrop-filter: blur(var(--glass-blur-light));
+  background: var(--bg-primary);
   border-bottom: 1px solid var(--divider);
   flex-shrink: 0;
   gap: var(--spacing-sm);
   box-sizing: border-box;
-  box-shadow: 0 1px 2px var(--overlay-light);
 }
 
 .content-header-icon {
@@ -160,7 +154,7 @@
   color: var(--interactive-normal);
   cursor: pointer;
   padding: var(--spacing-xs);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-size: var(--font-size-xl);
   transition: color var(--duration-fast) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
 }
@@ -218,7 +212,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
@@ -234,7 +228,6 @@
   border-bottom: 1px solid var(--divider);
   flex-shrink: 0;
   box-sizing: border-box;
-  box-shadow: 0 1px 2px var(--overlay-light);
 }
 
 .channel-sidebar-header-top {
@@ -253,7 +246,7 @@
 .sidebar-settings-btn {
   padding: var(--spacing-xs);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: none;
   color: var(--interactive-normal);
   cursor: pointer;
@@ -279,7 +272,7 @@
   flex: 1;
   padding: 6px 0;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--interactive-normal);
   cursor: pointer;

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -144,7 +144,6 @@
   display: flex;
   gap: var(--spacing-sm);
   margin-left: auto;
-  width: calc(var(--member-sidebar-width) - var(--spacing-lg));
   flex-shrink: 0;
 }
 

--- a/client/src/pages/AppLayout.css
+++ b/client/src/pages/AppLayout.css
@@ -162,7 +162,7 @@
   padding: var(--spacing-xs);
   border-radius: 4px;
   font-size: var(--font-size-xl);
-  transition: color 0.15s ease;
+  transition: color var(--duration-fast) var(--ease-out), background-color var(--duration-fast) var(--ease-out);
 }
 
 .header-action-btn:hover {

--- a/client/src/pages/PublicShell.css
+++ b/client/src/pages/PublicShell.css
@@ -27,8 +27,8 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 30% 40%, var(--brand-alpha-20) 0%, transparent 70%),
-    radial-gradient(ellipse 60% 70% at 70% 70%, var(--accent-alpha-08) 0%, transparent 70%);
+    radial-gradient(ellipse 80% 60% at 30% 40%, var(--brand-alpha-30) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 70% at 70% 70%, var(--accent-alpha-15) 0%, transparent 70%);
   animation: public-brand-drift 16s ease-in-out infinite alternate;
   pointer-events: none;
 }
@@ -36,13 +36,13 @@
 @keyframes public-brand-drift {
   0% {
     background:
-      radial-gradient(ellipse 80% 60% at 30% 40%, var(--brand-alpha-20) 0%, transparent 70%),
-      radial-gradient(ellipse 60% 70% at 70% 70%, var(--accent-alpha-08) 0%, transparent 70%);
+      radial-gradient(ellipse 80% 60% at 30% 40%, var(--brand-alpha-30) 0%, transparent 70%),
+      radial-gradient(ellipse 60% 70% at 70% 70%, var(--accent-alpha-15) 0%, transparent 70%);
   }
   100% {
     background:
-      radial-gradient(ellipse 70% 70% at 40% 50%, var(--brand-alpha-15) 0%, transparent 70%),
-      radial-gradient(ellipse 80% 50% at 60% 30%, var(--accent-alpha-10) 0%, transparent 70%);
+      radial-gradient(ellipse 70% 70% at 40% 50%, var(--brand-alpha-25) 0%, transparent 70%),
+      radial-gradient(ellipse 80% 50% at 60% 30%, var(--accent-alpha-20) 0%, transparent 70%);
   }
 }
 
@@ -112,7 +112,7 @@
   max-width: 420px;
   background: var(--glass-bg-primary);
   border: 1px solid var(--glass-border);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   padding: 2.5rem 2rem;
   backdrop-filter: blur(var(--glass-blur));
   -webkit-backdrop-filter: blur(var(--glass-blur));

--- a/client/src/styles/base-tokens.css
+++ b/client/src/styles/base-tokens.css
@@ -30,9 +30,9 @@
   --spacing-2xl: 2rem;
 
   /* Border radius */
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
   --radius-full: 9999px;
 
   /* Z-index scale */
@@ -45,6 +45,7 @@
 
   /* Transition timing */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --ease-in-out: cubic-bezier(0.45, 0, 0.55, 1);
   --duration-fast: 150ms;
   --duration-normal: 200ms;

--- a/client/src/styles/base-tokens.css
+++ b/client/src/styles/base-tokens.css
@@ -1,8 +1,8 @@
 /* Structural design tokens — do NOT override in custom themes */
 :root {
   /* Typography */
-  --font-display: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-ui: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
   /* Font weight — extended for richer hierarchy */

--- a/client/src/styles/base-tokens.css
+++ b/client/src/styles/base-tokens.css
@@ -1,9 +1,12 @@
 /* Structural design tokens — do NOT override in custom themes */
 :root {
   /* Typography */
-  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-display: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-ui: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Font weight — extended for richer hierarchy */
+  --font-weight-light: 300;
 
   /* Font sizes (rem-based for accessibility) */
   --font-size-micro: 0.6875rem;

--- a/client/src/styles/theme-default.css
+++ b/client/src/styles/theme-default.css
@@ -17,27 +17,27 @@
   --text-secondary: #8fa3b8;
   --text-muted: #7a8e9e;
   --text-link: #3ba8ba;
-  --text-positive: #4caf82;
-  --text-danger: #d05a4a;
-  --text-warning: #e8b84b;
+  --text-positive: #10b981;
+  --text-danger: #ef4444;
+  --text-warning: #f59e0b;
 
   /* Header colors */
   --header-primary: #f0f4f8;
   --header-secondary: #8fa3b8;
 
   /* Brand colors */
-  --brand-500: #2e8b9a;
-  --brand-560: #3ba8ba;
-  --bg-accent: #e8b84b;
-  --bg-accent-hover: #f0ca6a;
+  --brand-500: #0ea5c0;
+  --brand-560: #22d3ee;
+  --bg-accent: #f59e0b;
+  --bg-accent-hover: #fbbf24;
 
   /* Status colors */
-  --green-360: #4caf82;
-  --yellow-300: #e8b84b;
-  --red-400: #d05a4a;
-  --status-online: #4caf82;
-  --status-idle: #e8b84b;
-  --status-dnd: #d05a4a;
+  --green-360: #10b981;
+  --yellow-300: #f59e0b;
+  --red-400: #ef4444;
+  --status-online: #10b981;
+  --status-idle: #f59e0b;
+  --status-dnd: #ef4444;
   --status-offline: #4d6478;
 
   /* Interactive colors */
@@ -61,18 +61,18 @@
   --input-bg: #0a1016;
 
   /* Aliases */
-  --accent: #e8b84b;
-  --accent-hover: #f0ca6a;
-  --danger: #d05a4a;
-  --success: #4caf82;
-  --warning: #e8b84b;
+  --accent: #f59e0b;
+  --accent-hover: #fbbf24;
+  --danger: #ef4444;
+  --success: #10b981;
+  --warning: #f59e0b;
   --hover: rgba(143, 163, 184, 0.12);
   --active: rgba(143, 163, 184, 0.20);
 
   /* Brand-specific */
-  --color-encrypted: #4caf82;
-  --shadow-glow-brand: 0 0 16px rgba(46,139,154,0.3);
-  --shadow-glow-accent: 0 0 16px rgba(232,184,75,0.25);
+  --color-encrypted: #10b981;
+  --shadow-glow-brand: 0 0 20px rgba(14, 165, 192, 0.35);
+  --shadow-glow-accent: 0 0 20px rgba(245, 158, 11, 0.3);
 
   /* Glass effects */
   --glass-blur: 12px;
@@ -105,28 +105,28 @@
   --white-overlay-medium: rgba(255, 255, 255, 0.7);
 
   /* Brand alpha variants */
-  --brand-alpha-10: rgba(46, 139, 154, 0.1);
-  --brand-alpha-12: rgba(46, 139, 154, 0.12);
-  --brand-alpha-15: rgba(46, 139, 154, 0.15);
-  --brand-alpha-20: rgba(46, 139, 154, 0.2);
-  --brand-alpha-25: rgba(46, 139, 154, 0.25);
+  --brand-alpha-10: rgba(14, 165, 192, 0.1);
+  --brand-alpha-12: rgba(14, 165, 192, 0.12);
+  --brand-alpha-15: rgba(14, 165, 192, 0.15);
+  --brand-alpha-20: rgba(14, 165, 192, 0.2);
+  --brand-alpha-25: rgba(14, 165, 192, 0.25);
 
   /* Accent alpha variants */
-  --accent-alpha-08: rgba(232, 184, 75, 0.08);
-  --accent-alpha-10: rgba(232, 184, 75, 0.10);
-  --accent-alpha-15: rgba(232, 184, 75, 0.15);
-  --accent-alpha-20: rgba(232, 184, 75, 0.2);
-  --accent-alpha-25: rgba(232, 184, 75, 0.25);
-  --accent-alpha-30: rgba(232, 184, 75, 0.3);
+  --accent-alpha-08: rgba(245, 158, 11, 0.08);
+  --accent-alpha-10: rgba(245, 158, 11, 0.10);
+  --accent-alpha-15: rgba(245, 158, 11, 0.15);
+  --accent-alpha-20: rgba(245, 158, 11, 0.2);
+  --accent-alpha-25: rgba(245, 158, 11, 0.25);
+  --accent-alpha-30: rgba(245, 158, 11, 0.3);
 
   /* Danger alpha variants */
-  --danger-alpha-15: rgba(208, 90, 74, 0.15);
-  --danger-alpha-25: rgba(208, 90, 74, 0.25);
+  --danger-alpha-15: rgba(239, 68, 68, 0.15);
+  --danger-alpha-25: rgba(239, 68, 68, 0.25);
 
   /* Success alpha variants */
-  --success-alpha-15: rgba(76, 175, 130, 0.15);
-  --success-alpha-35: rgba(52, 211, 122, 0.35);
-  --success-alpha-40: rgba(76, 175, 130, 0.4);
+  --success-alpha-15: rgba(16, 185, 129, 0.15);
+  --success-alpha-35: rgba(16, 185, 129, 0.35);
+  --success-alpha-40: rgba(16, 185, 129, 0.4);
 }
 
 /* Shared dialog backdrop button — invisible full-area close target */

--- a/client/src/styles/utilities.css
+++ b/client/src/styles/utilities.css
@@ -62,7 +62,7 @@
   cursor: pointer;
   transition: background-color var(--duration-fast) var(--ease-out),
               color var(--duration-fast) var(--ease-out);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
 }
 
 .clickable:hover {

--- a/server-rs/src/db/read_queries.rs
+++ b/server-rs/src/db/read_queries.rs
@@ -29,7 +29,7 @@ pub fn get_unread_count(
          WHERE channel_id = ?1 AND deleted = 0
          AND created_at > COALESCE(
              (SELECT last_read_at FROM channel_reads WHERE user_id = ?2 AND channel_id = ?1),
-             '1970-01-01'
+             datetime('now')
          )",
         params![channel_id, user_id],
         |row| row.get(0),
@@ -52,7 +52,7 @@ pub fn get_unread_counts_for_team(
              AND m.created_at > COALESCE(
                  (SELECT cr.last_read_at FROM channel_reads cr
                   WHERE cr.user_id = ?1 AND cr.channel_id = c.id),
-                 '1970-01-01'
+                 datetime('now')
              )
          WHERE c.team_id = ?2
          GROUP BY c.id",


### PR DESCRIPTION
## Summary
First round of UI modernization — token updates, layout improvements, and component polish.

### Design Token Changes
- Vibrant colors: brand teal #0ea5c0, accent amber #f59e0b, saturated status colors
- Rounder surfaces: 6/10/14px radius scale
- Spring easing token, token-based transitions everywhere

### Layout
- Solid backgrounds on sidebars (removed CPU-heavy blur on fixed panels)
- Elevated content area (lighter bg, subtle left shadow)
- Glass blur composer with gradient fade effect
- Better focus rings (brand-colored, inset)

### Components
- Voice: webcam fills tile, local user mute/deafen/camera icons in channel list
- Messages: cleaner spacing, subtler hover, preserved newlines
- Unread count: fixed first-load showing all messages as unread
- Search: proper sizing, portal rendering, collapse on outside click
- Resize handle: min 240px / max 400px enforcement