### PR TITLE
fix(scripts): proxmox installer — use Ubuntu 24.04 template (glibc match)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ CTID=210 CT_HOSTNAME=chat MEMORY=2048 DISK_GB=16 IPV4="10.0.0.50/24,gw=10.0.0.1"
   bash -c "$(curl -fsSL https://raw.githubusercontent.com/dilla-chat/dilla-chat/main/scripts/install-proxmox-lxc.sh)"
 ```
 
-Common knobs: `CTID`, `CT_HOSTNAME`, `STORAGE` (auto-detected), `BRIDGE`, `IPV4`, `CORES`, `MEMORY`, `SWAP`, `DISK_GB`, `DILLA_PORT`, `RELEASE_TAG`. The full list is documented in the comment header at the top of [`scripts/install-proxmox-lxc.sh`](scripts/install-proxmox-lxc.sh).
+Common knobs: `CTID`, `CT_HOSTNAME`, `STORAGE` (auto-detected), `BRIDGE`, `IPV4`, `CORES`, `MEMORY`, `SWAP`, `DISK_GB`, `DILLA_PORT`, `RELEASE_TAG`, `TEMPLATE_PREFIX` (default `ubuntu-24.04-standard` to match the build glibc). The full list is documented in the comment header at the top of [`scripts/install-proxmox-lxc.sh`](scripts/install-proxmox-lxc.sh).
 
 After the script finishes:
 

--- a/scripts/install-proxmox-lxc.sh
+++ b/scripts/install-proxmox-lxc.sh
@@ -35,6 +35,11 @@ set -Eeuo pipefail
 : "${DILLA_PORT:=8080}"
 : "${RELEASE_TAG:=nightly}"
 : "${RELEASE_REPO:=dilla-chat/dilla-chat}"
+# Released binaries are built on ubuntu-latest (currently 24.04, glibc 2.39),
+# so the container needs ≥ that glibc to load them. Ubuntu 24.04 LTS matches.
+# Override with TEMPLATE_PREFIX=debian-13-standard once the release pipeline
+# moves to a lower glibc floor.
+: "${TEMPLATE_PREFIX:=ubuntu-24.04-standard}"
 
 readonly TIMER_LIMIT=120
 
@@ -129,7 +134,7 @@ elif ! pvesm status -storage "$STORAGE" &>/dev/null; then
   die "Storage '${STORAGE}' does not exist. Available rootdir storages: $(pvesm status -content rootdir 2>/dev/null | awk 'NR>1 {print $1}' | xargs)"
 fi
 
-# ---- Locate or download a Debian 12 template --------------------------------
+# ---- Locate or download the LXC template ------------------------------------
 
 msg_info "Refreshing template index"
 pveam update >/dev/null
@@ -137,10 +142,12 @@ msg_ok "Template index refreshed"
 
 template_name=$(
   pveam available --section system \
-    | awk '/^[[:space:]]*system[[:space:]]+debian-12-standard/ {print $2}' \
+    | awk -v prefix="$TEMPLATE_PREFIX" \
+        '$1=="system" && index($2, prefix)==1 {print $2}' \
     | sort -V | tail -n1
 )
-[[ -n "$template_name" ]] || die "No debian-12-standard template available from pveam."
+[[ -n "$template_name" ]] \
+  || die "No template matching '${TEMPLATE_PREFIX}' available from pveam. Override with TEMPLATE_PREFIX=…"
 
 template_path="${TEMPLATE_STORE}:vztmpl/${template_name}"
 local_path="/var/lib/vz/template/cache/${template_name}"


### PR DESCRIPTION
## Summary

Released `dilla-server-linux-*` artifacts are built on `ubuntu-latest` (currently 24.04, glibc 2.39). Debian 12 only has glibc 2.36, so the binary fails to load with:

```
/usr/local/bin/dilla-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

Switch the default LXC template to `ubuntu-24.04-standard` (glibc 2.39). Make the prefix overridable via `TEMPLATE_PREFIX=…` so users can pick a different distro once the release pipeline lowers its glibc floor.

## Follow-up

Open a separate PR pinning `release.yml`'s `linux-amd64` builder to `ubuntu-22.04` so the artifact is portable down to Debian 12 — then we can switch back to a Debian template (smaller footprint, faster cold-start).

## Test plan

- [ ] Destroy the previously-broken CT (`pct stop 121 && pct destroy 121 --force --purge`).
- [ ] Re-run installer — pulls `ubuntu-24.04-standard_24.04-N_amd64.tar.zst`, container comes up, `systemctl status dilla` is active.
- [ ] `pct exec <CTID> -- /usr/local/bin/dilla-server --version` returns cleanly (no glibc error).
- [ ] Override `TEMPLATE_PREFIX=debian-12-standard` reproduces the prior failure (sanity check that the variable plumbing works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)