### PR TITLE
feat(observability): emit HTTP access logs without requiring OTel

### DIFF
--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -76,16 +76,15 @@ async fn main() {
     // Create router and start server.
     let app = api::create_router(state);
 
-    // Wire OTel HTTP middleware if enabled.
-    let app = if cfg.otel_enabled {
-        let metrics = std::sync::Arc::new(observability::Metrics::new());
-        app.layer(axum::middleware::from_fn_with_state(
-            metrics,
-            observability::http_middleware,
-        ))
-    } else {
-        app
-    };
+    // HTTP middleware: emits one `tracing::info!` per request (the access log
+    // operators see via `journalctl -u dilla`) and records OTel spans/metrics
+    // on top. Metric/span calls become noops when OTel is disabled, so this
+    // is essentially free in that mode but still gives us the access log.
+    let metrics = std::sync::Arc::new(observability::Metrics::new());
+    let app = app.layer(axum::middleware::from_fn_with_state(
+        metrics,
+        observability::http_middleware,
+    ));
 
     start_server(&cfg, app).await;
 }


### PR DESCRIPTION
## Summary

`observability::http_middleware` emits one `tracing::info!(method, path, status, duration_ms)` per request — the structured access log operators see via `journalctl -u dilla`. But the middleware was only attached to the router when `DILLA_OTEL_ENABLED=true`, so anyone running without an OTLP collector saw only startup + error logs, with no way to observe request activity short of standing up a full tracing backend.

Attach the layer unconditionally. The OTel span / metric calls inside the middleware become noops when OTel is disabled (they hit the global noop providers), so the cost is one `Arc<Metrics>` allocation at boot + the log line itself.

## After this

```
$ journalctl -u dilla -f
... method=GET  path=/api/config         status=200 duration_ms=2.14  request
... method=POST path=/api/passkey/begin  status=200 duration_ms=8.31  request
... method=POST path=/api/auth/login     status=401 duration_ms=4.02  request
```

Set `DILLA_LOG_FORMAT=json` if you want to feed these into Loki / OpenSearch / Vector.

## Test plan

- [ ] `cargo test` (CI).
- [ ] Run the binary, hit `/api/config`, see one `request` log line per hit.
- [ ] Run with `DILLA_OTEL_ENABLED=true` — same log line plus the OTel span/metric still flow to the configured OTLP endpoint.
- [ ] Run with `DILLA_LOG_LEVEL=warn` — access logs disappear (they're `info`), errors stay; confirms the existing log filter still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)