### PR TITLE
fix(invites): unwrap createInvite response, match the server contract

### DIFF
--- a/client/src/pages/TeamSettings.test.tsx
+++ b/client/src/pages/TeamSettings.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../services/api', () => ({
     unbanMember: vi.fn().mockResolvedValue({}),
     updateMember: vi.fn().mockResolvedValue({}),
     listInvites: vi.fn().mockResolvedValue([]),
-    createInvite: vi.fn().mockResolvedValue({ invite: { id: 'inv-1', token: 'abc', created_by: 'admin', uses: 0, max_uses: null, expires_at: null } }),
+    createInvite: vi.fn().mockResolvedValue({ id: 'inv-1', token: 'abc', created_by: 'admin', uses: 0, max_uses: null, expires_at: null }),
     revokeInvite: vi.fn().mockResolvedValue({}),
   },
 }));
@@ -444,10 +444,8 @@ describe('TeamSettings', () => {
   it('creates invite with specific options and shows it in table', async () => {
     const { api } = await import('../services/api');
     vi.mocked(api.createInvite).mockResolvedValueOnce({
-      invite: {
-        id: 'inv-1', token: 'abc123', created_by: 'admin',
-        uses: 0, max_uses: 10, expires_at: '2025-06-01T00:00:00Z',
-      },
+      id: 'inv-1', token: 'abc123', created_by: 'admin',
+      uses: 0, max_uses: 10, expires_at: '2025-06-01T00:00:00Z',
     });
     navigateToTab('invites');
     fireEvent.click(screen.getByText('Create Invite'));
@@ -618,7 +616,7 @@ describe('TeamSettings', () => {
     navigateToTab('invites');
     fireEvent.click(screen.getByText('Create Invite'));
     expect(screen.getByText('Creating...')).toBeInTheDocument();
-    resolveCreate!({ invite: { id: 'inv-1', token: 'abc', created_by: 'admin', uses: 0, max_uses: null, expires_at: null } });
+    resolveCreate!({ id: 'inv-1', token: 'abc', created_by: 'admin', uses: 0, max_uses: null, expires_at: null });
   });
 
   it('removes member role when toggling off', async () => {

--- a/client/src/pages/TeamSettings/InvitesTab.tsx
+++ b/client/src/pages/TeamSettings/InvitesTab.tsx
@@ -22,8 +22,8 @@ export default function InvitesTab({ teamId }: Readonly<{ teamId: string }>) {
     try {
       const maxUsesNum = Number(maxUses) || undefined;
       const expiryHours = Number(expiry) || undefined;
-      const result = (await api.createInvite(teamId, maxUsesNum, expiryHours)) as { invite: Invite };
-      setInvites((prev) => [result.invite, ...prev]);
+      const invite = (await api.createInvite(teamId, maxUsesNum, expiryHours)) as Invite;
+      setInvites((prev) => [invite, ...prev]);
     } catch {
       // Invite creation may fail due to permissions; UI stays functional.
     } finally {


### PR DESCRIPTION
## Summary

`InvitesTab.tsx` assumed the create-invite response was `{ invite: Invite }` and read `result.invite`. The server returns the invite **directly** (`server-rs/src/api/invites.rs:71` does `json_ok(invite)`), so `result.invite` was always `undefined`. The undefined object got pushed into the table state, and the very next render crashed with:

```
TypeError: can't access property "token", e is undefined
  at InvitesTab (table row)
```

The server-side write succeeded — reloading the page hit `listInvites` (correctly typed) and showed the real invite, which is what made the bug look "weird but recoverable."

## Why the tests didn't catch it

The unit-test mocks for `createInvite` were set up to return the **wrapped** shape, matching the client's mistaken expectation rather than the server's actual contract. So both halves of the mismatch lived in test fixtures and the discrepancy never surfaced.

This patch:

1. Reads the response as flat `Invite` in `InvitesTab.tsx` (matches `listInvites`, `getInviteInfo`, and every other invite endpoint).
2. Flattens both mock fixtures in `TeamSettings.test.tsx` so the tests now exercise the actual server shape.

## Test plan

- [x] `npx vitest run src/pages/TeamSettings.test.tsx` — 77/77 pass with the flattened mocks.
- [ ] In a running deployment, click "Create Invite" → invite shows in the table immediately, no `TypeError`, copy-link works.
- [ ] Reload → invite still there and identical to the optimistic insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)