### PR TITLE
fix(install): default fresh LXC to DILLA_INSECURE=true with scoped CORS

### DIFF
--- a/scripts/install-proxmox-lxc.sh
+++ b/scripts/install-proxmox-lxc.sh
@@ -586,6 +586,22 @@ msg_info "Creating LXC ${CTID} (${CT_HOSTNAME})"
 
 db_passphrase=$(head -c 32 /dev/urandom | base64 | tr -d '+/=' | head -c 32)
 
+# CORS allow-list derived from DILLA_DOMAIN. The dilla-server defaults
+# to permissive CORS and emits a SECURITY warning at startup until this
+# is set — we lock it down to the single browser origin the user will
+# actually hit:
+#   - domain mode  → https://<domain>            (terminated by the reverse proxy)
+#   - testing mode → http://localhost:<port>     (matches the SSH tunnel hint
+#                                                 printed at end-of-install)
+#   - noninteractive with no domain set → leave empty (the heredoc skips it)
+if [[ "$DILLA_DOMAIN" == "localhost" ]]; then
+  allowed_origins="http://localhost:${DILLA_PORT}"
+elif [[ -n "$DILLA_DOMAIN" ]]; then
+  allowed_origins="https://${DILLA_DOMAIN}"
+else
+  allowed_origins=""
+fi
+
 # Compose net0 with optional VLAN tag + IPv6 spec.
 net0="name=eth0,bridge=${BRIDGE},ip=${IPV4}"
 [[ -n "$VLAN" ]]                        && net0+=",tag=${VLAN}"
@@ -687,7 +703,13 @@ pct exec "$CTID" -- bash -c "
 DILLA_PORT=${DILLA_PORT}
 DILLA_DATA_DIR=/var/lib/dilla
 DILLA_DB_PASSPHRASE=${db_passphrase}
+# This LXC install runs plaintext HTTP behind an external reverse proxy
+# (see header comment + post-install hint below). DILLA_INSECURE=true
+# is what the dilla-server requires to allow that — without it the
+# service refuses to start.
+DILLA_INSECURE=true
 ${DILLA_DOMAIN:+DILLA_DOMAIN=${DILLA_DOMAIN}}
+${allowed_origins:+DILLA_ALLOWED_ORIGINS=${allowed_origins}}
 EOF
   chown root:dilla /etc/dilla/dilla.env
   chmod 0640 /etc/dilla/dilla.env
@@ -765,6 +787,8 @@ if [[ "$DILLA_DOMAIN" == "localhost" ]]; then
 elif [[ -n "$DILLA_DOMAIN" ]]; then
   echo -e " ${DGN}Next:${CL} point your reverse proxy at ${BL}${container_ip:-<ct-ip>}:${DILLA_PORT}${CL}"
   echo -e "       and serve it as ${BL}https://${DILLA_DOMAIN}${CL}."
+  echo -e "       ${YW}CORS${CL} is pinned to ${BL}${allowed_origins}${CL} — update"
+  echo -e "       ${BL}DILLA_ALLOWED_ORIGINS${CL} in ${BL}/etc/dilla/dilla.env${CL} if you move the proxy hostname."
 else
   echo -e " ${YW}No DILLA_DOMAIN set${CL} — passkey registration will fail until you"
   echo -e "       front the LXC with a reverse proxy on a domain and append"


### PR DESCRIPTION
## Summary

A fresh `scripts/install-proxmox-lxc.sh` run boots the LXC into a crashloop because the generated `/etc/dilla/dilla.env` never sets `DILLA_INSECURE=true` (nor any TLS config), and the dilla-server refuses to start in plaintext.

```
ERROR: refusing to start in plaintext.
  Either:
    - set DILLA_TLS_CERT and DILLA_TLS_KEY to a valid certificate pair, or
    - set DILLA_INSECURE=true to explicitly run an unencrypted HTTP server (dev only).
```

The script's whole point (header comment line 24, prompt at 467, post-install hint at 766) is that *the LXC runs plaintext and an external reverse proxy terminates TLS*. So the right install default is `DILLA_INSECURE=true` plus a CORS allow-list scoped to the user-supplied domain (so the server's wide-open CORS warning doesn't fire either).

## Change

Single file: `scripts/install-proxmox-lxc.sh`.

1. **Derive `allowed_origins`** from `DILLA_DOMAIN` just after `db_passphrase` (host-side, before `pct exec`):
   - domain mode → `https://<domain>`
   - testing mode (`DILLA_DOMAIN=localhost`) → `http://localhost:<port>` (matches the existing SSH-tunnel hint)
   - noninteractive with no domain → empty (heredoc skips it, server's existing SECURITY warning kicks in)
2. **Heredoc emits** `DILLA_INSECURE=true` (unconditional) and `${allowed_origins:+DILLA_ALLOWED_ORIGINS=${allowed_origins}}` using the same conditional shape already in place for `DILLA_DOMAIN`.
3. **Post-install hint** in the domain branch now tells the user CORS is pinned to the derived origin so they know to update `DILLA_ALLOWED_ORIGINS` in `/etc/dilla/dilla.env` if they later move the proxy hostname.

No systemd-unit change — `EnvironmentFile=/etc/dilla/dilla.env` already sources the new vars.

## Test plan

- [x] `bash -n scripts/install-proxmox-lxc.sh` → syntax ok
- [x] dry-run the env-file heredoc with three variable combos (domain set, `localhost`, empty) → emits the expected lines and skips the conditional ones when empty
- [ ] real install on a fresh Proxmox CT (the reporter's existing `dilla` CT can be re-installed, or manually patch `/etc/dilla/dilla.env` and `systemctl restart dilla.service` to confirm the values fix the crashloop)

## Out of scope

- TLS-in-dilla support (Option B). Users who want the server to terminate TLS itself can edit `/etc/dilla/dilla.env` manually to add `DILLA_TLS_CERT` / `DILLA_TLS_KEY` and remove `DILLA_INSECURE=true`.
- Adding shellcheck to CI for `scripts/install-proxmox-lxc.sh` — `.github/workflows/ci.yml` doesn't currently lint shell scripts. Separate ticket.