### PR TITLE
fix(css): restore div-like rendering for buttons after S6848 a11y refactor

### DIFF
--- a/client/src/shell/chat.css
+++ b/client/src/shell/chat.css
@@ -22,15 +22,61 @@
   text-rendering: optimizeLegibility;
 }
 
-/* Resize handles — sit on top of the column gutters. 6px hit area, 1px line. */
+/* S6848 a11y refactor turned several interactive <div>s into <button>s.
+   Buttons inherit chrome (border, padding, font-size, background, focus
+   outline, default font, …) from the browser; the original CSS for these
+   classes assumed a <div>. Reset the UA chrome so each class keeps its
+   own design without leaking button defaults. Add classes here as more
+   elements get converted. */
+.rail-item,
+.rail-add,
+.channel-row,
+.dm-row,
+.cat-collapsible,
+.pip-edge,
+.pip-move,
+.resize-handle {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  outline: 0;
+  box-shadow: none;
+}
+/* Row-like elements that used to be block-level <div>s. <button> defaults
+   to inline-block + content width; restore the full-width fill so the
+   row spans the sidebar instead of shrink-wrapping to its label. */
+.channel-row,
+.dm-row,
+.cat-collapsible {
+  width: 100%;
+}
+.rail-item:focus-visible,
+.channel-row:focus-visible,
+.dm-row:focus-visible,
+.cat-collapsible:focus-visible {
+  /* Keep an a11y-visible focus ring without bleeding it into the resting
+     state. Buttons get an :focus styling from the UA otherwise. */
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+/* .rail-add keeps its own dashed border that .rail-add { … } sets below. */
+
+/* Resize handles — sit on top of the column gutters. 6px hit area, 1px line.
+   UA button reset comes from the top-of-file rule (S6848). */
 .resize-handle {
   position: absolute;
   top: 0; bottom: 0;
   width: 6px;
   z-index: 5;
   cursor: col-resize;
-  background: transparent;
   transition: background .12s;
+  outline: none;
 }
 .resize-handle::after {
   content: '';


### PR DESCRIPTION
## Summary

Recent Sonar S6848 / S6478 refactors converted several interactive `<div>`s in `client/src/shell/ChatApp.tsx` into semantic `<button>`s. The existing CSS for these classes assumed a `<div>` and didn't reset the UA button chrome — so after the refactor:

- **resize handles** in the chat shell rendered as visible chrome buttons with a "drag to resize" tooltip
- **channel rows** / **DM rows** / **category headers** shrink-wrapped to their text instead of filling the sidebar (because `<button>` defaults to `inline-block`, not `display: block`)
- focus outlines leaked into the resting state

Repro: on `main`, open the app → the sidebar rows are visibly shorter than the sidebar width and resize handles appear as button chrome on the right gutter.

## Change

`client/src/shell/chat.css` only — adds a top-of-file reset block for the converted classes, plus a `width: 100%` follow-up for the rows that originally rendered as block-level `<div>`s. Focus visibility is preserved via `:focus-visible` with `outline-offset: -2px` so the a11y ring sits inside the row.

Diff is +48 / -2 lines.

## Test plan

- [x] `npm run build` clean
- [x] Hard-refresh against a fresh release build — resize handles invisible, channel/dm rows fill the sidebar, category headers fill the sidebar, focus ring visible only on keyboard navigation
- [ ] Visual diff vs `main` (manual)

If you spot any other class still showing button defaults, add it to the comma list at the top of `chat.css` — the comment above the rule lists the pattern.