### PR TITLE
fix(auth): gate useTeamSync restore on cryptoReady to fix reload bounce

### DIFF
--- a/client/src/hooks/useTeamSync.ts
+++ b/client/src/hooks/useTeamSync.ts
@@ -252,8 +252,14 @@ function restoreApiConnections(teams: Map<string, { baseUrl: string; token: stri
 /**
  * Handles API connection restoration, auth-error redirects, WS setup,
  * sync:init on connect, and REST-fallback data loading.
+ *
+ * `cryptoReady` gates the API-restore effect — the encrypted teams blob
+ * lives in sessionStorage and is hydrated asynchronously by
+ * `useCryptoRestore`. Firing restoreApiConnections before that pumps
+ * through means we'd restore with an empty teams Map on every reload
+ * and bounce the user to /onboarding.
  */
-export function useTeamSync(activeTeamId: string | null): { authChecked: boolean; dataLoaded: RefObject<Set<string>> } {
+export function useTeamSync(activeTeamId: string | null, cryptoReady = true): { authChecked: boolean; dataLoaded: RefObject<Set<string>> } {
   const navigate = useNavigate();
   const { teams } = useAuthStore();
   const { setTeam, setChannels, setMembers, setRoles } = useTeamStore();
@@ -289,9 +295,15 @@ export function useTeamSync(activeTeamId: string | null): { authChecked: boolean
     });
   }, [navigate]);
 
-  // Restore API connections from persisted teams on mount
+  // Restore API connections from persisted teams on mount.
+  // Wait for cryptoReady so the encrypted teams blob (sessionStorage,
+  // hydrated by useCryptoRestore) has actually been decrypted into the
+  // store before we read .size. Without this gate, the first effect
+  // run on reload sees an empty teams Map and `authChecked` flips true
+  // → AppLayout redirects to /onboarding even though the user is
+  // perfectly authenticated. See `restoreEncryptedAuthDataIntoStore`.
   useEffect(() => {
-    if (apiRestored.current) return;
+    if (apiRestored.current || !cryptoReady) return;
     apiRestored.current = true;
     console.log(`[AppLayout] Restoring API connections for ${teams.size} teams`);
     restoreApiConnections(teams);
@@ -305,7 +317,7 @@ export function useTeamSync(activeTeamId: string | null): { authChecked: boolean
     } else {
       setAuthChecked(true);
     }
-  }, [teams]);
+  }, [teams, cryptoReady]);
 
   // Auto-select first team if none active
   const { setActiveTeam } = useTeamStore();

--- a/client/src/pages/AppLayout.tsx
+++ b/client/src/pages/AppLayout.tsx
@@ -120,7 +120,11 @@ export default function AppLayout() {
 
   // --- Extracted hooks ---
   const { cryptoReady } = useCryptoRestore();
-  const { authChecked, dataLoaded } = useTeamSync(activeTeamId);
+  // useTeamSync must wait for cryptoReady — the encrypted teams blob in
+  // sessionStorage is hydrated asynchronously by useCryptoRestore, and
+  // firing restoreApiConnections before that pumps through sees an empty
+  // teams Map and bounces the user to /onboarding on every reload.
+  const { authChecked, dataLoaded } = useTeamSync(activeTeamId, cryptoReady);
 
   // Redirect to join/setup if no teams — wait until auth is validated so we
   // don't redirect during the brief window before persisted state is confirmed.


### PR DESCRIPTION
## Summary

Reloading any authenticated page on `dilla.thim.dev` lands on `/onboarding?mode=invite` with the banner "An identity already exists on this device". Cookie is set correctly, JWT is valid, IDB has the identity — but the SPA decides client-side that you're logged out and routes you away.

## Root cause

Race between two `useEffect`s after `useAuthStore`'s synchronous init:

1. `loadPersistedTeams()` reads the **plaintext** `dilla_teams` sessionStorage key as the sync fallback. But `persistEncryptedMap` removes that key after writing the encrypted `dilla_teams:enc` blob. So sync init → empty `teams` Map.
2. `useTeamSync` mounts, fires its restore effect with `teams.size == 0`, sets `apiRestored.current = true`, calls `setAuthChecked(true)`.
3. `AppLayout` sees `authChecked && teams.size === 0` → redirects to `/onboarding`.
4. **Then** `useCryptoRestore`'s async effect calls `restoreEncryptedAuthDataIntoStore()`, decrypts the `_ENC` blob, populates the store — too late, the navigation already happened.

The user's console log on the bad reload shows `[AppLayout] Restoring API connections for 0 teams` immediately followed by the route change. No 401, no server-side issue.

## Change

Two files:

- `client/src/hooks/useTeamSync.ts` — accept a `cryptoReady` param and gate the restore `useEffect` on it.
- `client/src/pages/AppLayout.tsx` — pass `cryptoReady` from `useCryptoRestore` into `useTeamSync`.

Net diff: +21 / −5 lines.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run useTeamSync.test.ts AppLayout.test.tsx` → 124 tests pass
- [ ] manual: reload an authenticated page on a deployed build, confirm you stay on `/app` instead of bouncing to `/onboarding`

This is one of a small cluster of post-S6848-refactor / post-H-13d auth-cookie fixes:
- #138 — CSS resets for div→button refactor
- #139 — register/bootstrap weren't setting `__dilla_jwt` cookie
- this PR — useTeamSync wasn't waiting for async store hydration