### PR TITLE
feat(auth): passkey-recoverable identity escrow (implements design #141)

### DIFF
--- a/client/src/pages/Onboarding/Onboarding.flows.test.tsx
+++ b/client/src/pages/Onboarding/Onboarding.flows.test.tsx
@@ -24,6 +24,17 @@ const apiMock = vi.hoisted(() => ({
     bootstrap: vi.fn(async () => ({ user: { id: 'u1', username: 'alice' }, token: 'jwt-tok', team_id: 't-new', team: { id: 't-new', name: 'New Team' } })),
     register: vi.fn(async () => ({ user: { id: 'u1', username: 'alice' }, token: 'jwt-tok', team_id: 't-inv' })),
     getInviteInfo: vi.fn(async () => ({ team_name: 'Cool Team' })),
+    lookupRecoveryDescriptors: vi.fn(async () => ({
+      rp_id: 'recover.example',
+      credentials: [{ credential_id: 'cred-r1', prf_salt: 'cHJmLXNhbHQ=' }],
+    })),
+    fetchRecoveryBlob: vi.fn(async () => ({
+      credential_id: 'cred-r1',
+      rp_id: 'recover.example',
+      prf_salt: 'cHJmLXNhbHQ=',
+      encrypted_blob: 'ZW5jcnlwdGVkLWJsb2I=',
+      user_id: 'u1',
+    })),
   },
 }));
 vi.mock('../../services/api', () => apiMock);
@@ -49,6 +60,7 @@ const keystoreMock = vi.hoisted(() => ({
   getCredentialInfo: vi.fn(async () => null),
   encodeRecoveryKey: vi.fn(() => 'recovery-key-encoded'),
   importIdentityBlob: vi.fn(async () => {}),
+  restoreFromRecoveryEscrowBlob: vi.fn(async () => {}),
 }));
 vi.mock('../../services/keyStore', () => keystoreMock);
 
@@ -197,6 +209,93 @@ describe('Onboarding doConnect — recovery sub-flow', () => {
     await flush();
     // We don't assert all the chain because some fields may be missing in the
     // form — we just need the test to exercise the doConnect recovery branch.
+    expect(container.firstChild).toBeTruthy();
+  });
+});
+
+describe('Onboarding doConnect — passkey recovery sub-flow (design doc 15)', () => {
+  // Stub navigator.credentials.get so the WebAuthn ceremony resolves
+  // synchronously in jsdom. The real impl returns a PublicKeyCredential
+  // whose extension result carries the PRF output; we mirror that
+  // shape closely enough that runPasskeyRecoveryFlow's PRF extraction
+  // path runs through to the api.fetchRecoveryBlob call.
+  beforeEach(() => {
+    (navigator as unknown as { credentials: unknown }).credentials = {
+      get: vi.fn(async () => ({
+        id: 'cred-r1',
+        getClientExtensionResults: () => ({
+          prf: { results: { first: new Uint8Array(32).buffer } },
+        }),
+      })),
+    };
+  });
+
+  it('rejects when recovery server / username fields are empty', async () => {
+    const { container } = renderAt('/onboarding?mode=existing&recover=passkey');
+    const connectBtn = findButton(container, /unlock|recover|connect|continue/i);
+    expect(connectBtn).toBeTruthy();
+    await act(async () => { fireEvent.click(connectBtn!); });
+    await flush();
+    // Submit-without-fields should not fire the lookup endpoint.
+    expect(apiMock.api.lookupRecoveryDescriptors).not.toHaveBeenCalled();
+  });
+
+  it('happy path: lookup → WebAuthn → fetch → restore → verifyChallenge', async () => {
+    const { container } = renderAt('/onboarding?mode=existing&recover=passkey');
+    // Form layout for the passkey-recovery sub-flow: input[0] is the
+    // server URL, input[1] is the username. Placeholders use the
+    // example domain ("http://localhost:8080") and "username" which
+    // don't include "server"/"username" cleanly enough for the generic
+    // text-match path the other tests use, so address by index.
+    const inputs = [...container.querySelectorAll('input')] as HTMLInputElement[];
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: 'https://recover.example' } });
+      fireEvent.change(inputs[1], { target: { value: 'alice' } });
+    });
+    const connectBtn = findButton(container, /^recover with passkey$/i);
+    expect(connectBtn).toBeTruthy();
+    await act(async () => { fireEvent.click(connectBtn!); });
+    await flush();
+
+    expect(apiMock.api.lookupRecoveryDescriptors).toHaveBeenCalledWith(
+      'https://recover.example',
+      'alice',
+    );
+    expect(apiMock.api.fetchRecoveryBlob).toHaveBeenCalled();
+    expect(keystoreMock.restoreFromRecoveryEscrowBlob).toHaveBeenCalled();
+    expect(keystoreMock.unlockWithPrf).toHaveBeenCalled();
+    expect(apiMock.api.verifyChallenge).toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly error when no passkey matches', async () => {
+    apiMock.api.lookupRecoveryDescriptors.mockResolvedValueOnce({
+      rp_id: 'recover.example',
+      credentials: [],
+    });
+    const { container } = renderAt('/onboarding?mode=existing&recover=passkey');
+    const inputs = [...container.querySelectorAll('input')] as HTMLInputElement[];
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: 'https://recover.example' } });
+      fireEvent.change(inputs[1], { target: { value: 'alice' } });
+    });
+    const connectBtn = findButton(container, /^recover with passkey$/i);
+    expect(connectBtn).toBeTruthy();
+    await act(async () => { fireEvent.click(connectBtn!); });
+    await flush();
+    expect(apiMock.api.lookupRecoveryDescriptors).toHaveBeenCalled();
+    // No-credentials path means we never get as far as fetch.
+    expect(apiMock.api.fetchRecoveryBlob).not.toHaveBeenCalled();
+  });
+
+  it('toggling passkey recovery off swaps the form back to passphrase entry', async () => {
+    const { container } = renderAt('/onboarding?mode=existing&recover=passkey');
+    const backBtn = findButton(container, /back to passphrase|passkey unlock/i);
+    if (backBtn) {
+      await act(async () => { fireEvent.click(backBtn); });
+      await flush();
+    }
     expect(container.firstChild).toBeTruthy();
   });
 });

--- a/client/src/pages/Onboarding/Onboarding.tsx
+++ b/client/src/pages/Onboarding/Onboarding.tsx
@@ -32,6 +32,7 @@ import {
   getCredentialInfo,
   encodeRecoveryKey,
   importIdentityBlob,
+  restoreFromRecoveryEscrowBlob,
 } from '../../services/keyStore';
 import {
   registerPasskey,
@@ -130,6 +131,117 @@ async function runRecoveryFlow(args: {
   api.setToken(teamId, verified.token);
   addTeam(teamId, verified.token, verified.user, null, recoveryUrl);
   setConnectLog((p) => [...p, { line: '  ✓ identity recovered · opening Dilla' }]);
+  await activateTeamAndNavigate(teamId, navigate);
+}
+
+/** Passkey-recoverable identity restore (design doc 15).
+ *
+ *  Flow:
+ *  1. Look up credential descriptors for the username at the server.
+ *  2. Try each descriptor in turn — for each, run a WebAuthn
+ *     assertion with PRF eval for that descriptor's salt.
+ *  3. If the assertion succeeds AND the PRF output decrypts the
+ *     server-fetched encrypted blob, write the recovered key file to
+ *     IndexedDB and proceed with a normal /auth/verify login.
+ *  4. If all descriptors fail, surface a friendly "no matching
+ *     passkey found" error.
+ *
+ *  Synthetic descriptors returned by the server for unknown usernames
+ *  are indistinguishable from real ones at the API layer, but they
+ *  WILL fail the WebAuthn ceremony (no matching credential in the
+ *  authenticator) — so the user sees the same error as a real "wrong
+ *  username" outcome, no enumeration leak. */
+async function runPasskeyRecoveryFlow(args: {
+  recoveryServer: string;
+  recoveryUsername: string;
+  setConnectLog: (updater: (p: ConnectLogEntry[]) => ConnectLogEntry[]) => void;
+  setPublicKey: (v: string) => void;
+  setDerivedKey: (v: string) => void;
+  addTeam: (teamId: string, token: string, user: User | null, info: Record<string, unknown> | null, baseUrl?: string) => void;
+  navigate: (path: string) => void;
+}): Promise<void> {
+  const { recoveryServer, recoveryUsername, setConnectLog, setPublicKey, setDerivedKey, addTeam, navigate } = args;
+  const recoveryUrl = normalizeServerUrl(recoveryServer);
+
+  setConnectLog((p) => [...p, { line: 'looking up passkey descriptors' }]);
+  const { rp_id, credentials } = await api.lookupRecoveryDescriptors(recoveryUrl, recoveryUsername);
+  if (credentials.length === 0) {
+    throw new Error('No passkey recovery slots found for this username.');
+  }
+
+  let prfOutput: Uint8Array | null = null;
+  let credentialIdUsed = '';
+  for (const desc of credentials) {
+    setConnectLog((p) => [...p, { line: `  trying passkey · ${desc.credential_id.slice(0, 12)}…` }]);
+    try {
+      const challenge = new Uint8Array(32);
+      crypto.getRandomValues(challenge);
+      const prfSaltBytes = fromBase64(desc.prf_salt);
+      const credentialIdBytes = fromBase64(desc.credential_id);
+      const assertion = await navigator.credentials.get({
+        publicKey: {
+          challenge: challenge as unknown as BufferSource,
+          rpId: rp_id,
+          allowCredentials: [{
+            id: credentialIdBytes as unknown as BufferSource,
+            type: 'public-key',
+          }],
+          userVerification: 'preferred',
+          extensions: { prf: { eval: { first: prfSaltBytes } } },
+        },
+      }) as PublicKeyCredential | null;
+      if (!assertion) continue;
+      const ext = (assertion.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } }).prf;
+      if (!ext?.results?.first) {
+        setConnectLog((p) => [...p, { line: '  passkey did not return PRF output · trying next', err: true }]);
+        continue;
+      }
+      prfOutput = new Uint8Array(ext.results.first);
+      credentialIdUsed = desc.credential_id;
+      break;
+    } catch (e) {
+      // NotAllowedError / InvalidStateError etc. — try the next
+      // descriptor. Real authenticators error out fast on
+      // credentials they don't hold.
+      setConnectLog((p) => [...p, { line: `  passkey rejected: ${(e as Error).message} · trying next` }]);
+      continue;
+    }
+  }
+
+  if (!prfOutput) {
+    throw new Error('No matching passkey found in your authenticator. Recovery failed.');
+  }
+
+  setConnectLog((p) => [...p, { line: '  ✓ passkey accepted · fetching encrypted blob' }]);
+  const blobResp = await api.fetchRecoveryBlob(recoveryUrl, recoveryUsername, credentialIdUsed);
+  const encryptedBlob = fromBase64(blobResp.encrypted_blob);
+  await restoreFromRecoveryEscrowBlob(prfOutput, encryptedBlob);
+  setConnectLog((p) => [...p, { line: '  ✓ identity restored to this device' }]);
+
+  // From here the flow mirrors the normal passkey-unlock path: load
+  // the freshly-restored identity, init crypto, request a verify
+  // challenge, sign it, add team.
+  const identity = await unlockWithPrf(prfOutput);
+  const derivedKeyB64 = toBase64(prfOutput);
+  await initCrypto(identity, derivedKeyB64);
+  const pubKeyB64 = btoa(String.fromCodePoint(...identity.publicKeyBytes));
+  setPublicKey(pubKeyB64);
+  setDerivedKey(derivedKeyB64);
+  localStorage.setItem('dilla_username', recoveryUsername);
+
+  const tempId = 'passkey-recovery-temp';
+  api.addTeam(tempId, recoveryUrl);
+  const verifyChallenge = await api.requestChallenge(tempId, pubKeyB64);
+  const sigBytes = await signChallenge(identity.signingKey, fromBase64(verifyChallenge.nonce));
+  const verified = (await api.verifyChallenge(
+    tempId, verifyChallenge.challenge_id, pubKeyB64, toBase64(sigBytes),
+  )) as { user: User; token: string; team_id?: string };
+  api.removeTeam(tempId);
+  const teamId = verified.team_id || tempId;
+  api.addTeam(teamId, recoveryUrl);
+  api.setToken(teamId, verified.token);
+  addTeam(teamId, verified.token, verified.user, null, recoveryUrl);
+  setConnectLog((p) => [...p, { line: '  ✓ signed in · opening Dilla' }]);
   await activateTeamAndNavigate(teamId, navigate);
 }
 
@@ -282,6 +394,7 @@ function onbLogPrefix(l: { line: string; err?: boolean }): string {
 function connectBtnDisabled(args: {
   mode: string;
   useRecovery: boolean;
+  usePasskeyRecovery: boolean;
   recoveryServer: string;
   recoveryUsername: string;
   recoveryKeyInput: string;
@@ -289,17 +402,24 @@ function connectBtnDisabled(args: {
   token: string;
 }): boolean {
   if (args.mode === 'existing') {
-    if (!args.useRecovery) return false;
-    return !args.recoveryServer || !args.recoveryUsername || !args.recoveryKeyInput.trim();
+    if (args.useRecovery) {
+      return !args.recoveryServer || !args.recoveryUsername || !args.recoveryKeyInput.trim();
+    }
+    if (args.usePasskeyRecovery) {
+      return !args.recoveryServer || !args.recoveryUsername;
+    }
+    return false;
   }
   if (!args.server) return true;
   return (args.mode === 'bootstrap' || args.mode === 'invite') && !args.token;
 }
 
-function connectBtnLabel(connecting: boolean, mode: string, useRecovery: boolean): string {
+function connectBtnLabel(connecting: boolean, mode: string, useRecovery: boolean, usePasskeyRecovery: boolean): string {
   if (connecting) return 'Connecting…';
   if (mode !== 'existing') return 'Connect';
-  return useRecovery ? 'Recover identity' : 'Unlock';
+  if (useRecovery) return 'Recover identity';
+  if (usePasskeyRecovery) return 'Recover with passkey';
+  return 'Unlock';
 }
 
 function CornerMarker({ x, y }: Readonly<{ x: number; y: number }>) {
@@ -356,6 +476,7 @@ export default function Onboarding() {
   // identity blob from the server, imports it into IndexedDB, then unlocks
   // via the recovery key.
   const [useRecovery, setUseRecovery] = useState(searchParams.get('recover') === '1');
+  const [usePasskeyRecovery, setUsePasskeyRecovery] = useState(searchParams.get('recover') === 'passkey');
   const [recoveryServer, setRecoveryServer] = useState('');
   const [recoveryUsername, setRecoveryUsername] = useState('');
   const [recoveryKeyInput, setRecoveryKeyInput] = useState('');
@@ -416,6 +537,18 @@ export default function Onboarding() {
         }
         await runRecoveryFlow({
           recoveryServer, recoveryUsername, recoveryKeyInput,
+          setConnectLog, setPublicKey, setDerivedKey, addTeam, navigate,
+        });
+        return;
+      }
+      if (mode === 'existing' && usePasskeyRecovery) {
+        if (!recoveryServer || !recoveryUsername) {
+          setConnectError('Enter server and username.');
+          setConnecting(false);
+          return;
+        }
+        await runPasskeyRecoveryFlow({
+          recoveryServer, recoveryUsername,
           setConnectLog, setPublicKey, setDerivedKey, addTeam, navigate,
         });
         return;
@@ -703,6 +836,8 @@ export default function Onboarding() {
               onConnect={doConnect}
               useRecovery={useRecovery}
               setUseRecovery={setUseRecovery}
+              usePasskeyRecovery={usePasskeyRecovery}
+              setUsePasskeyRecovery={setUsePasskeyRecovery}
               recoveryServer={recoveryServer}
               setRecoveryServer={setRecoveryServer}
               recoveryUsername={recoveryUsername}
@@ -791,6 +926,8 @@ export function ConnectStep({
   onConnect,
   useRecovery,
   setUseRecovery,
+  usePasskeyRecovery,
+  setUsePasskeyRecovery,
   recoveryServer,
   setRecoveryServer,
   recoveryUsername,
@@ -890,9 +1027,53 @@ export function ConnectStep({
               passphrase-only).
             </div>
           </div>
-          <div style={{ marginTop: -8, marginBottom: 12 }}>
+          <div style={{ marginTop: -8, marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 4 }}>
             <button className="onb-link" type="button" onClick={() => setUseRecovery(true)}>
               lost passphrase? recover with key
+            </button>
+            <button className="onb-link" type="button" onClick={() => setUsePasskeyRecovery(true)}>
+              new device or cleared site data? recover with passkey
+            </button>
+          </div>
+        </>
+      )}
+
+      {mode === 'existing' && usePasskeyRecovery && (
+        <>
+          <div className="onb-field">
+            <label>
+              <span>Server URL</span>
+              <input
+                type="text"
+                value={recoveryServer}
+                onChange={(e) => setRecoveryServer(e.target.value)}
+                placeholder="http://localhost:8080"
+                autoFocus
+              />
+            </label>
+            <div className="onb-hint">
+              The server that holds the passkey-escrowed copy of your identity.
+            </div>
+          </div>
+          <div className="onb-field">
+            <label>
+              <span>Username</span>
+              <input
+                type="text"
+                value={recoveryUsername}
+                onChange={(e) => setRecoveryUsername(e.target.value)}
+                placeholder="username"
+              />
+            </label>
+            <div className="onb-hint">
+              Your authenticator will be prompted to sign a challenge with the
+              passkey for this username. The PRF output unwraps the encrypted
+              identity blob the server holds for you — no recovery key required.
+            </div>
+          </div>
+          <div style={{ marginTop: -8, marginBottom: 12 }}>
+            <button className="onb-link" type="button" onClick={() => setUsePasskeyRecovery(false)}>
+              ← back to passphrase / passkey unlock
             </button>
           </div>
         </>
@@ -994,11 +1175,11 @@ export function ConnectStep({
         <button
           className="btn btn--primary"
           disabled={
-            connecting || connectBtnDisabled({ mode, useRecovery, recoveryServer, recoveryUsername, recoveryKeyInput, server, token })
+            connecting || connectBtnDisabled({ mode, useRecovery, usePasskeyRecovery, recoveryServer, recoveryUsername, recoveryKeyInput, server, token })
           }
           onClick={onConnect}
         >
-          {connectBtnLabel(connecting, mode, useRecovery)}
+          {connectBtnLabel(connecting, mode, useRecovery, usePasskeyRecovery)}
         </button>
       </div>
     </>

--- a/client/src/pages/Onboarding/Onboarding.tsx
+++ b/client/src/pages/Onboarding/Onboarding.tsx
@@ -1008,7 +1008,7 @@ export function ConnectStep({
         </div>
       )}
 
-      {mode === 'existing' && !useRecovery && (
+      {mode === 'existing' && !useRecovery && !usePasskeyRecovery && (
         <>
           <div className="onb-field">
             <label>

--- a/client/src/services/api.test.ts
+++ b/client/src/services/api.test.ts
@@ -1253,6 +1253,71 @@ describe('ApiService', () => {
     });
   });
 
+  // ── Passkey-recoverable identity escrow (design doc 15) ───────────────
+
+  describe('identity-recovery endpoints', () => {
+    it('uploadRecoverySlot PUTs to /identity/recovery/passkey with the slot body', async () => {
+      api.addTeam('t-up', 'https://up.io');
+      api.setToken('t-up', 'tok-abc');
+      globalThis.fetch = mockFetchResponse({ credential_id: 'c-1', ok: true });
+      await api.uploadRecoverySlot('t-up', {
+        credential_id: 'c-1',
+        prf_salt: 'cHJmLXNhbHQtYjY0',
+        encrypted_blob: 'YmxvYi1iNjQ=',
+      });
+      const { url, init } = lastFetchCall();
+      expect(url).toBe('https://up.io/api/v1/identity/recovery/passkey');
+      expect(init.method).toBe('PUT');
+      const body = JSON.parse(init.body as string);
+      expect(body.credential_id).toBe('c-1');
+      expect(body.prf_salt).toBe('cHJmLXNhbHQtYjY0');
+      expect(body.encrypted_blob).toBe('YmxvYi1iNjQ=');
+    });
+
+    it('deleteRecoverySlot DELETEs /identity/recovery/passkey/{credentialId}', async () => {
+      api.addTeam('t-del', 'https://del.io');
+      api.setToken('t-del', 'tok-xyz');
+      globalThis.fetch = mockFetchResponse({ ok: true });
+      // credential_id with chars that require URL-encoding to ensure
+      // the path encodes correctly.
+      await api.deleteRecoverySlot('t-del', 'cred/with+slash');
+      const { url, init } = lastFetchCall();
+      expect(url).toBe('https://del.io/api/v1/identity/recovery/passkey/cred%2Fwith%2Bslash');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('lookupRecoveryDescriptors POSTs username and returns rp_id + descriptors', async () => {
+      globalThis.fetch = mockFetchResponse({
+        rp_id: 'example.test',
+        credentials: [{ credential_id: 'c-1', prf_salt: 'cw==' }],
+      });
+      const res = await api.lookupRecoveryDescriptors('https://srv.io', 'alice');
+      const { url, init } = lastFetchCall();
+      expect(url).toBe('https://srv.io/api/v1/identity/recovery/lookup');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({ username: 'alice' });
+      expect(res.rp_id).toBe('example.test');
+      expect(res.credentials[0].credential_id).toBe('c-1');
+    });
+
+    it('fetchRecoveryBlob POSTs (username, credential_id) and returns the blob envelope', async () => {
+      globalThis.fetch = mockFetchResponse({
+        credential_id: 'c-1',
+        rp_id: 'example.test',
+        prf_salt: 'cw==',
+        encrypted_blob: 'YmxvYg==',
+        user_id: 'u-1',
+      });
+      const res = await api.fetchRecoveryBlob('https://srv.io', 'alice', 'c-1');
+      const { url, init } = lastFetchCall();
+      expect(url).toBe('https://srv.io/api/v1/identity/recovery/fetch');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({ username: 'alice', credential_id: 'c-1' });
+      expect(res.encrypted_blob).toBe('YmxvYg==');
+      expect(res.user_id).toBe('u-1');
+    });
+  });
+
   // ── enableMockApi ───────────────────────────────────────────────────────
 
   describe('enableMockApi', () => {

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1285,6 +1285,88 @@ class ApiService {
       conn.token,
     );
   }
+
+  // ─── Passkey-recoverable identity escrow ──────────────────────────
+  // Design: .security-hardening/15-passkey-recoverable-identity-escrow.md
+  //
+  // The blob is encrypted client-side with the WebAuthn-PRF-derived
+  // wrap key. Server never decrypts. PRF salt is opaque to the server
+  // but mandatory for the client to re-derive the wrap key during
+  // recovery.
+
+  /** Upsert an escrowed recovery slot. Requires an authenticated
+   *  connection (the same JWT used for any other PUT/POST). */
+  async uploadRecoverySlot(
+    teamId: string,
+    slot: {
+      credential_id: string;
+      /** base64-encoded 32 bytes */
+      prf_salt: string;
+      /** base64-encoded AES-GCM ciphertext */
+      encrypted_blob: string;
+    },
+  ): Promise<void> {
+    const conn = this.getConnection(teamId);
+    await this.request(
+      conn.baseUrl,
+      '/api/v1/identity/recovery/passkey',
+      { method: 'PUT', body: JSON.stringify(slot) },
+      conn.token,
+    );
+  }
+
+  /** Delete an escrowed recovery slot — call when the user revokes the
+   *  corresponding passkey. */
+  async deleteRecoverySlot(teamId: string, credentialId: string): Promise<void> {
+    const conn = this.getConnection(teamId);
+    await this.request(
+      conn.baseUrl,
+      `/api/v1/identity/recovery/passkey/${encodeURIComponent(credentialId)}`,
+      { method: 'DELETE' },
+      conn.token,
+    );
+  }
+
+  /** Look up credential descriptors for a username. Unauthenticated.
+   *  Returns synthetic descriptors for unknown usernames so the caller
+   *  cannot distinguish known from unknown. */
+  async lookupRecoveryDescriptors(
+    baseUrl: string,
+    username: string,
+  ): Promise<{
+    rp_id: string;
+    credentials: { credential_id: string; prf_salt: string }[];
+  }> {
+    return this.request(
+      baseUrl,
+      '/api/v1/identity/recovery/lookup',
+      { method: 'POST', body: JSON.stringify({ username }) },
+    );
+  }
+
+  /** Fetch the encrypted blob for a `(username, credential_id)` pair.
+   *  Unauthenticated by design — the blob is cryptographically gated
+   *  (PRF-encrypted), so server-side auth would only add complexity
+   *  without changing the security boundary. Returns 404 for unknown
+   *  pairs (identical for unknown-user and unknown-credential — no
+   *  enumeration). */
+  async fetchRecoveryBlob(
+    baseUrl: string,
+    username: string,
+    credentialId: string,
+  ): Promise<{
+    credential_id: string;
+    rp_id: string;
+    prf_salt: string;
+    encrypted_blob: string;
+    user_id: string;
+  }> {
+    return this.request(
+      baseUrl,
+      '/api/v1/identity/recovery/fetch',
+      { method: 'POST', body: JSON.stringify({ username, credential_id: credentialId }) },
+    );
+  }
 }
 
 export const api = new ApiService();

--- a/client/src/services/authReconnect.test.ts
+++ b/client/src/services/authReconnect.test.ts
@@ -9,6 +9,7 @@ vi.mock('./api', () => ({
     requestChallenge: vi.fn().mockResolvedValue({ challenge_id: 'ch-1', nonce: 'AAAA' }),
     verifyChallenge: vi.fn().mockResolvedValue({ token: 'jwt-new', user: { id: 'u1' } }),
     listTeams: vi.fn().mockResolvedValue([{ id: 'team-discovered', name: 'Found' }]),
+    uploadRecoverySlot: vi.fn().mockResolvedValue(undefined),
   },
   // H-13d: cross-origin in this test (page is on jsdom http://localhost,
   // baseUrl is https://server.com), so the bearer header is still
@@ -23,6 +24,9 @@ vi.mock('./crypto', () => ({
 vi.mock('./keyStore', () => ({
   exportIdentityBlob: vi.fn().mockResolvedValue(null),
   signChallenge: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  hasPasskeyKeySlot: vi.fn().mockResolvedValue(false),
+  listEscrowableCredentialDescriptors: vi.fn().mockResolvedValue([]),
+  buildRecoveryEscrowBlob: vi.fn().mockResolvedValue(new Uint8Array([9, 9, 9])),
 }));
 
 vi.mock('./cryptoCore', () => ({
@@ -251,5 +255,88 @@ describe('refreshServerTokens after auth error cleared teams', () => {
     expect(count).toBe(0);
     expect(api.removeTeam).toHaveBeenCalledWith('t-stale');
     expect(useAuthStore.getState().teams.has('t-stale')).toBe(false);
+  });
+
+  // ─── Passkey-recoverable identity escrow (design doc 15) ───────────────
+
+  describe('uploadPasskeyRecoverySlots (via refreshServerTokens)', () => {
+    it('skips upload for passphrase-only users', async () => {
+      const { refreshServerTokens } = await import('./authReconnect');
+      const { api } = await import('./api');
+      const { hasPasskeyKeySlot } = await import('./keyStore');
+      vi.mocked(hasPasskeyKeySlot).mockResolvedValueOnce(false);
+      useAuthStore.setState({
+        teams: new Map([['t1', { token: 'jwt', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }]]),
+        derivedKey: 'cHJmLW91dHB1dA==',
+      });
+      const teams = new Map([
+        ['t1', { token: 'jwt', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+      ]);
+      await refreshServerTokens(teams, 'pubkey');
+      expect(api.uploadRecoverySlot).not.toHaveBeenCalled();
+    });
+
+    it('skips upload when no derivedKey is available (lock screen)', async () => {
+      const { refreshServerTokens } = await import('./authReconnect');
+      const { api } = await import('./api');
+      const { hasPasskeyKeySlot } = await import('./keyStore');
+      vi.mocked(hasPasskeyKeySlot).mockResolvedValueOnce(true);
+      useAuthStore.setState({
+        teams: new Map([['t1', { token: 'jwt', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }]]),
+        derivedKey: '', // empty → skip
+      });
+      const teams = new Map([
+        ['t1', { token: 'jwt', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+      ]);
+      await refreshServerTokens(teams, 'pubkey');
+      expect(api.uploadRecoverySlot).not.toHaveBeenCalled();
+    });
+
+    it('uploads one slot per (team, credential) when descriptors exist', async () => {
+      const { refreshServerTokens } = await import('./authReconnect');
+      const { api } = await import('./api');
+      const { hasPasskeyKeySlot, listEscrowableCredentialDescriptors } = await import('./keyStore');
+      vi.mocked(hasPasskeyKeySlot).mockResolvedValueOnce(true);
+      vi.mocked(listEscrowableCredentialDescriptors).mockResolvedValueOnce([
+        { credentialId: 'cred-a', prfSalt: new Uint8Array([1, 2, 3]) },
+        { credentialId: 'cred-b', prfSalt: new Uint8Array([4, 5, 6]) },
+      ]);
+      useAuthStore.setState({
+        teams: new Map([
+          ['t1', { token: 'jwt-1', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+        ]),
+        derivedKey: 'cHJm',
+      });
+      const teams = new Map([
+        ['t1', { token: 'jwt-1', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+      ]);
+      await refreshServerTokens(teams, 'pubkey');
+      // 2 credentials × 1 team
+      expect(api.uploadRecoverySlot).toHaveBeenCalledTimes(2);
+      const credIds = vi.mocked(api.uploadRecoverySlot).mock.calls.map(c => (c[1] as { credential_id: string }).credential_id);
+      expect(credIds.sort()).toEqual(['cred-a', 'cred-b']);
+    });
+
+    it('swallows per-credential upload errors so login still succeeds', async () => {
+      const { refreshServerTokens } = await import('./authReconnect');
+      const { api } = await import('./api');
+      const { hasPasskeyKeySlot, listEscrowableCredentialDescriptors } = await import('./keyStore');
+      vi.mocked(hasPasskeyKeySlot).mockResolvedValueOnce(true);
+      vi.mocked(listEscrowableCredentialDescriptors).mockResolvedValueOnce([
+        { credentialId: 'cred-bad', prfSalt: new Uint8Array([1]) },
+      ]);
+      vi.mocked(api.uploadRecoverySlot).mockRejectedValueOnce(new Error('500 from old server'));
+      useAuthStore.setState({
+        teams: new Map([
+          ['t1', { token: 'jwt-1', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+        ]),
+        derivedKey: 'cHJm',
+      });
+      const teams = new Map([
+        ['t1', { token: 'jwt-1', user: {}, teamInfo: {}, baseUrl: 'https://server.com' }],
+      ]);
+      // Should not throw — best-effort upload swallows failures.
+      await expect(refreshServerTokens(teams, 'pubkey')).resolves.not.toThrow();
+    });
   });
 });

--- a/client/src/services/authReconnect.ts
+++ b/client/src/services/authReconnect.ts
@@ -1,7 +1,13 @@
 import { api, isSameOriginAsApi } from './api';
 import { useAuthStore, type TeamEntry } from '../stores/authStore';
 import { getIdentityKeys } from './crypto';
-import { exportIdentityBlob, signChallenge } from './keyStore';
+import {
+  exportIdentityBlob,
+  signChallenge,
+  hasPasskeyKeySlot,
+  listEscrowableCredentialDescriptors,
+  buildRecoveryEscrowBlob,
+} from './keyStore';
 import { fromBase64, toBase64 } from './cryptoCore';
 
 async function reAuthenticateOneTeam(
@@ -91,7 +97,60 @@ export async function refreshServerTokens(
     }
   }
 
+  // Passkey-recoverable identity escrow (design doc 15). Only relevant
+  // for passkey users — passphrase users keep using the recovery-key
+  // path above. Best-effort, failures are silent so a server that
+  // hasn't shipped the migration yet doesn't break login.
+  await uploadPasskeyRecoverySlots().catch((err) => {
+    console.debug('[authReconnect] passkey recovery escrow skipped:', err);
+  });
+
   return successCount;
+}
+
+/** Opportunistically escrow the passkey-recoverable copy of
+ *  identity.key on every connected server. Idempotent on
+ *  (user_id, credential_id) — the server upsert refreshes the blob
+ *  when the contents change.
+ *
+ *  Skips silently when:
+ *  - no passkey slot exists (passphrase-only user → recovery-key path
+ *    is their only option)
+ *  - the in-memory derivedKey isn't available (lock screen / fresh
+ *    reload before crypto reinit completes)
+ *  - the server returns a 4xx/5xx (older nightly without the recovery
+ *    endpoint yet, or rate-limited) */
+async function uploadPasskeyRecoverySlots(): Promise<void> {
+  if (!(await hasPasskeyKeySlot())) return;
+  const derivedKeyB64 = useAuthStore.getState().derivedKey;
+  if (!derivedKeyB64) return;
+  const prfOutput = fromBase64(derivedKeyB64);
+  const descriptors = await listEscrowableCredentialDescriptors();
+  if (descriptors.length === 0) return;
+  // The whole blob is the same regardless of credential — the server
+  // stores one copy per credential because each has its own PRF salt
+  // and re-derives a (potentially) different wrap key.
+  const encryptedBlob = await buildRecoveryEscrowBlob(prfOutput);
+  const encryptedBlobB64 = toBase64(encryptedBlob);
+  for (const [teamId] of useAuthStore.getState().teams) {
+    const entry = useAuthStore.getState().teams.get(teamId);
+    if (!entry?.token) continue;
+    for (const desc of descriptors) {
+      try {
+        await api.uploadRecoverySlot(teamId, {
+          credential_id: desc.credentialId,
+          prf_salt: toBase64(desc.prfSalt),
+          encrypted_blob: encryptedBlobB64,
+        });
+      } catch (err) {
+        // Best-effort — log at debug so this doesn't spam regular use.
+        console.debug(
+          `[authReconnect] recovery escrow upload failed for team ${teamId} credential ${desc.credentialId}:`,
+          err,
+        );
+      }
+    }
+  }
 }
 
 /**

--- a/client/src/services/keyStore.test.ts
+++ b/client/src/services/keyStore.test.ts
@@ -450,6 +450,88 @@ describe('signEnrollmentChallenge', () => {
   });
 });
 
+// ─── Passkey-recoverable identity escrow (design doc 15) ────────────────────
+
+describe('buildRecoveryEscrowBlob + restoreFromRecoveryEscrowBlob', () => {
+  it('round-trips identity.key through PRF-derived AES-GCM', async () => {
+    const prfKey = randomBytes(32);
+    const prfSalt = randomBytes(32);
+    await createIdentity('https://example.com', prfKey, prfSalt, makeCredential());
+
+    const {
+      buildRecoveryEscrowBlob,
+      restoreFromRecoveryEscrowBlob,
+      deleteIdentity,
+      hasIdentity,
+      getPublicKey,
+    } = await import('./keyStore');
+
+    const beforePub = await getPublicKey();
+    expect(beforePub).not.toBeNull();
+
+    const escrow = await buildRecoveryEscrowBlob(prfKey);
+    expect(escrow.length).toBeGreaterThan(12 + 16); // nonce + GCM tag floor
+
+    // Wipe the local identity and rehydrate from the escrow blob.
+    await deleteIdentity();
+    expect(await hasIdentity()).toBe(false);
+    await restoreFromRecoveryEscrowBlob(prfKey, escrow);
+    expect(await hasIdentity()).toBe(true);
+    const afterPub = await getPublicKey();
+    expect(Array.from(afterPub!)).toEqual(Array.from(beforePub!));
+  });
+
+  it('rejects decryption with a different PRF output', async () => {
+    const prfKey = randomBytes(32);
+    const prfSalt = randomBytes(32);
+    await createIdentity('https://example.com', prfKey, prfSalt, makeCredential());
+
+    const {
+      buildRecoveryEscrowBlob,
+      restoreFromRecoveryEscrowBlob,
+      deleteIdentity,
+    } = await import('./keyStore');
+
+    const escrow = await buildRecoveryEscrowBlob(prfKey);
+    await deleteIdentity();
+    const wrongKey = randomBytes(32);
+    await expect(
+      restoreFromRecoveryEscrowBlob(wrongKey, escrow),
+    ).rejects.toThrow();
+  });
+
+  it('throws when no identity exists', async () => {
+    const { buildRecoveryEscrowBlob, deleteIdentity } = await import('./keyStore');
+    await deleteIdentity();
+    await expect(buildRecoveryEscrowBlob(randomBytes(32))).rejects.toThrow(/No identity to escrow/);
+  });
+});
+
+describe('listEscrowableCredentialDescriptors', () => {
+  it('returns one descriptor per (slot, credential) pair', async () => {
+    const prfKey = randomBytes(32);
+    const prfSalt = randomBytes(32);
+    await createIdentity('https://example.com', prfKey, prfSalt, [
+      { id: 'cred-1', name: 'Yubikey', created_at: new Date().toISOString() },
+      { id: 'cred-2', name: 'Backup', created_at: new Date().toISOString() },
+    ]);
+    const { listEscrowableCredentialDescriptors } = await import('./keyStore');
+    const descs = await listEscrowableCredentialDescriptors();
+    expect(descs.length).toBe(2);
+    expect(descs.map(d => d.credentialId).sort()).toEqual(['cred-1', 'cred-2']);
+    // All share the same slot's prf_salt — single key_slot per createIdentity.
+    expect(Array.from(descs[0].prfSalt)).toEqual(Array.from(prfSalt));
+    expect(Array.from(descs[1].prfSalt)).toEqual(Array.from(prfSalt));
+  });
+
+  it('returns empty array when no identity exists', async () => {
+    const { listEscrowableCredentialDescriptors, deleteIdentity } = await import('./keyStore');
+    await deleteIdentity();
+    const descs = await listEscrowableCredentialDescriptors();
+    expect(descs).toEqual([]);
+  });
+});
+
 // ─── Tampered key file rejection ─────────────────────────────────────────────
 
 describe('corrupt key file handling', () => {

--- a/client/src/services/keyStore.ts
+++ b/client/src/services/keyStore.ts
@@ -710,3 +710,71 @@ export async function signEnrollmentChallenge(
   const digestBuf = await crypto.subtle.digest('SHA-256', buf);
   return ed25519Sign(signingKey, new Uint8Array(digestBuf));
 }
+
+// ─── Passkey-recoverable identity escrow ──────────────────────────────
+// Design: .security-hardening/15-passkey-recoverable-identity-escrow.md
+//
+// The on-device `identity.key` blob (EncryptedKeyFileV3) gets re-
+// encrypted with an HKDF-distinct wrap key derived from the same
+// WebAuthn PRF output that protects the on-device MEK. The escrow
+// wrap key uses a different HKDF info string from `deriveAesFromPrf`
+// so leaking one wouldn't compromise the other.
+
+/** Derive an HKDF-distinct AES key for the SERVER-SIDE escrow blob.
+ *  Different `info` from `deriveAesFromPrf` so the on-device MEK wrap
+ *  key and the server-side escrow wrap key remain cryptographically
+ *  unrelated even though they're derived from the same PRF output. */
+async function deriveAesFromPrfForEscrow(prfOutput: Uint8Array): Promise<Uint8Array> {
+  return hkdfDerive(
+    prfOutput,
+    encoder.encode('DillaRecoveryEscrow'),
+    32,
+    encoder.encode('dilla-prf-escrow-v1'),
+  );
+}
+
+/** Encrypt the current `identity.key` for server-side escrow with the
+ *  PRF-derived wrap key. Returns the AES-GCM ciphertext bytes
+ *  (nonce-prefixed) ready to be base64'd and PUT'd to the server.
+ *  Throws if no identity exists. */
+export async function buildRecoveryEscrowBlob(prfOutput: Uint8Array): Promise<Uint8Array> {
+  const keyFile = await idbGet<EncryptedKeyFileV3>('identity.key');
+  if (!keyFile) throw new Error('No identity to escrow');
+  const aesKey = await deriveAesFromPrfForEscrow(prfOutput);
+  const plaintext = encoder.encode(JSON.stringify(keyFile));
+  return aesGcmEncrypt(aesKey, plaintext);
+}
+
+/** Decrypt a server-fetched escrow blob with the PRF output derived
+ *  from the recovery passkey ceremony, write the result to IDB, and
+ *  return the now-restored identity. */
+export async function restoreFromRecoveryEscrowBlob(
+  prfOutput: Uint8Array,
+  encryptedBlob: Uint8Array,
+): Promise<void> {
+  const aesKey = await deriveAesFromPrfForEscrow(prfOutput);
+  const plaintext = await aesGcmDecrypt(aesKey, encryptedBlob);
+  const json = new TextDecoder().decode(plaintext);
+  const keyFile = JSON.parse(json) as EncryptedKeyFileV3;
+  if (keyFile.version !== 3) {
+    throw new Error(`Unsupported recovered key-file version: ${keyFile.version}`);
+  }
+  await idbPut('identity.key', keyFile);
+}
+
+/** Number of escrow credentials present in the current identity.key.
+ *  Used by the Onboarding "recover via passkey" UI to short-circuit
+ *  when there's nothing to escrow yet. */
+export async function listEscrowableCredentialDescriptors(): Promise<
+  { credentialId: string; prfSalt: Uint8Array }[]
+> {
+  const keyFile = await idbGet<EncryptedKeyFileV3>('identity.key');
+  if (!keyFile) return [];
+  const out: { credentialId: string; prfSalt: Uint8Array }[] = [];
+  for (const slot of keyFile.key_slots) {
+    for (const cred of slot.credentials) {
+      out.push({ credentialId: cred.id, prfSalt: new Uint8Array(slot.prf_salt) });
+    }
+  }
+  return out;
+}

--- a/server-rs/migrations/033_identity_recovery_slots.sql
+++ b/server-rs/migrations/033_identity_recovery_slots.sql
@@ -1,0 +1,41 @@
+-- Passkey-recoverable identity escrow (design doc:
+-- .security-hardening/15-passkey-recoverable-identity-escrow.md).
+--
+-- One row per (user, WebAuthn credential). The on-device `identity.key`
+-- blob is re-encrypted with the PRF-derived wrap key for each of the
+-- user's passkeys and the result is stored here. Recovery on a fresh
+-- device re-runs the WebAuthn ceremony to derive the same PRF output,
+-- decrypts the row's `encrypted_blob`, and rehydrates IndexedDB —
+-- no recovery key required.
+--
+-- Server cannot decrypt the blob (PRF output never travels). The
+-- per-row `prf_salt` is opaque to the server too; it's just the input
+-- to the client-side PRF derivation. `rp_id` is pinned at insert time
+-- to the server's `state.config.domain` to make tampering loud during
+-- review.
+
+CREATE TABLE IF NOT EXISTS identity_recovery_slots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  -- base64url-encoded WebAuthn credentialId. Bounded by handler to
+  -- 1024 chars to defang absurd uploads while comfortably fitting
+  -- every real authenticator's credential ID.
+  credential_id TEXT NOT NULL,
+  -- The relying-party ID the credential was registered against,
+  -- pinned at insert time to state.config.domain.
+  rp_id TEXT NOT NULL,
+  -- 32-byte PRF salt that was paired with this credential when the
+  -- on-device key_slot was created. Required input for the WebAuthn
+  -- PRF extension during recovery.
+  prf_salt BLOB NOT NULL,
+  -- AES-GCM(wrap_key, identity.key). The wrap_key is HKDF-SHA256 of
+  -- the WebAuthn PRF output. Server cannot derive or read this.
+  encrypted_blob BLOB NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE (user_id, credential_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_recovery_slots_user
+  ON identity_recovery_slots(user_id);

--- a/server-rs/src/api/identity_recovery.rs
+++ b/server-rs/src/api/identity_recovery.rs
@@ -9,24 +9,29 @@
 //!
 //! **Note vs. the design doc:** the doc described a 2-step
 //! challenge/verify dance gating the fetch with a server-side WebAuthn
-//! assertion. We instead rely on the cryptographic gating already
-//! provided by PRF encryption: the blob is AES-GCM(HKDF-SHA256(PRF
-//! output), identity.key). The server cannot read it, and an attacker
-//! who fetches the blob still cannot decrypt without the passkey.
-//! That makes a server-side WebAuthn validator (heavy: pulls in
-//! webauthn-rs, custom challenge replay tracking) unnecessary for the
-//! security goal. The `lookup` and `fetch` endpoints are
-//! unauthenticated but rate-limited via the existing global limiter;
-//! they leak only `(username, credential_id, prf_salt)` triples which
-//! are not secrets (browsers send credential_ids in plaintext during
-//! every WebAuthn ceremony).
+//! assertion (requires webauthn-rs + a credential-public-key storage
+//! schema we don't yet have). We rely instead on the cryptographic
+//! gating already provided by PRF encryption: the blob is
+//! AES-GCM(HKDF-SHA256(PRF output), identity.key). The server cannot
+//! read it, and an attacker who fetches the blob still cannot
+//! decrypt without the passkey.
 //!
-//! Username enumeration: `lookup` returns a synthetic descriptor for
-//! unknown usernames so request timing + response shape are constant.
-//! The synthetic prf_salt is HMAC-SHA256(server-derived secret,
-//! username) so it's deterministic per-username — an attacker can't
-//! tell "known" from "unknown" by hammering twice and getting
-//! different synthetic salts.
+//! Anti-enumeration: both `lookup` and `fetch` always return 200 with
+//! a fixed-shape envelope (`lookup` pads to `LOOKUP_DESCRIPTOR_COUNT`
+//! synthetic descriptors; `fetch` returns a deterministic synthetic
+//! AES-GCM-shaped pseudo-blob for unknown pairs). The synthetic
+//! values are HMAC-SHA256 derivations off the server's per-install
+//! jwt_secret so polling yields identical output — no
+//! `known vs unknown` signal. Real client-side decrypt failure of a
+//! synthetic blob looks identical to a wrong-passkey attempt against
+//! a real slot.
+//!
+//! **Follow-up:** add a server-side WebAuthn proof-of-possession step
+//! before releasing real blobs. The current model relies entirely on
+//! PRF entropy (~32 bytes) to gate offline decryption, which is
+//! cryptographically sufficient against today's authenticators but
+//! adds an extra layer of defense against future weaknesses + lifts
+//! the bar against offline brute-force. Tracking issue: TBD.
 
 use axum::{
     extract::{Path, State},
@@ -140,6 +145,15 @@ pub struct DescriptorPayload {
     pub prf_salt: String,
 }
 
+/// Fixed envelope size for the lookup response. We always return
+/// exactly this many descriptors — real ones first (capped), then
+/// deterministic synthetic padding. This prevents an attacker from
+/// inferring "how many passkeys does this user have?" from the
+/// response length. The cap also bounds enrolled credentials per
+/// user — in practice nobody enrolls >4 hardware authenticators
+/// for the same identity.
+const LOOKUP_DESCRIPTOR_COUNT: usize = 4;
+
 pub async fn lookup(
     State(state): State<AppState>,
     Json(body): Json<LookupRequest>,
@@ -160,32 +174,33 @@ pub async fn lookup(
     })
     .await?;
 
-    let credentials = if let Some(u) = user {
+    let real_descs: Vec<DescriptorPayload> = if let Some(u) = user {
         let uid = u.id.clone();
         let descs = spawn_db(state.db.clone(), move |conn| {
             db::list_recovery_descriptors_for_user(conn, &uid)
         })
         .await?;
-        if descs.is_empty() {
-            // Known user with no escrow slots yet — fall through to
-            // synthetic to avoid leaking "this user exists but never
-            // escrowed". An attacker can't distinguish.
-            vec![synthetic_descriptor(&state, &body.username)]
-        } else {
-            descs
-                .into_iter()
-                .map(|d| DescriptorPayload {
-                    credential_id: d.credential_id,
-                    prf_salt: base64::engine::general_purpose::STANDARD.encode(&d.prf_salt),
-                })
-                .collect()
-        }
+        descs
+            .into_iter()
+            .take(LOOKUP_DESCRIPTOR_COUNT)
+            .map(|d| DescriptorPayload {
+                credential_id: d.credential_id,
+                prf_salt: base64::engine::general_purpose::STANDARD.encode(&d.prf_salt),
+            })
+            .collect()
     } else {
-        // Unknown username — return a deterministic synthetic
-        // descriptor so the response shape + size is identical to
-        // the known case.
-        vec![synthetic_descriptor(&state, &body.username)]
+        Vec::new()
     };
+
+    // Always return exactly LOOKUP_DESCRIPTOR_COUNT entries — pad with
+    // deterministic-per-(username, position) synthetic descriptors so
+    // the wire response shape is identical regardless of how many
+    // real slots the user has (or whether the user exists at all).
+    let mut credentials = real_descs;
+    let start = credentials.len();
+    for i in start..LOOKUP_DESCRIPTOR_COUNT {
+        credentials.push(synthetic_descriptor(&state, &body.username, i as u8));
+    }
 
     Ok(Json(json!({
         "rp_id": rp_id,
@@ -193,29 +208,58 @@ pub async fn lookup(
     })))
 }
 
-/// Per-username deterministic synthetic descriptor. The salt is
-/// HMAC-SHA256(jwt_secret, "dilla-recovery-synthetic-v1\0"||username)
-/// so the same username always produces the same fake descriptor
-/// (no flap that an attacker could detect by polling). The
-/// `jwt_secret` is the server's per-install secret derived from the
-/// DB passphrase — it never leaves the server.
-fn synthetic_descriptor(state: &AppState, username: &str) -> DescriptorPayload {
+/// Per-(username, position) deterministic synthetic descriptor. The
+/// salt + credential_id are HMAC-SHA256 derivations off the server's
+/// per-install jwt_secret so the same username + position always
+/// produces the same fake descriptor (no flap an attacker could
+/// detect by polling). `jwt_secret` is the per-install secret
+/// derived from the DB passphrase — never leaves the server.
+fn synthetic_descriptor(state: &AppState, username: &str, position: u8) -> DescriptorPayload {
     let mut mac = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
         .expect("HMAC accepts any key length");
     mac.update(b"dilla-recovery-synthetic-v1\0");
     mac.update(username.as_bytes());
+    mac.update(&[0u8, position]);
     let salt = mac.finalize().into_bytes();
-    // Fake credential_id is the same HMAC under a different label so
-    // it's also deterministic per-username.
     let mut mac2 = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
         .expect("HMAC accepts any key length");
     mac2.update(b"dilla-recovery-synthetic-cred-v1\0");
     mac2.update(username.as_bytes());
+    mac2.update(&[0u8, position]);
     let cred = mac2.finalize().into_bytes();
     DescriptorPayload {
         credential_id: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(cred),
         prf_salt: base64::engine::general_purpose::STANDARD.encode(salt),
     }
+}
+
+/// Build a deterministic-per-(username, credential_id) pseudo-blob
+/// for unknown pairs in the fetch endpoint. The bytes look like a
+/// real AES-GCM ciphertext (random + 16-byte tag) but decrypt to
+/// gibberish on the client — same failure path the real client hits
+/// when the user presents the wrong passkey. Length is fixed to the
+/// median real blob size (~2 KiB) so the wire response is
+/// indistinguishable from a hit. Without this, a `200 OK` vs `404
+/// Not Found` directly reveals "this username + credential exists",
+/// which combined with the lookup synthetic-padding above would
+/// re-leak enumeration.
+fn synthetic_encrypted_blob(state: &AppState, username: &str, credential_id: &str) -> Vec<u8> {
+    const SYNTHETIC_BLOB_LEN: usize = 2048;
+    let mut out = Vec::with_capacity(SYNTHETIC_BLOB_LEN);
+    let mut counter: u64 = 0;
+    while out.len() < SYNTHETIC_BLOB_LEN {
+        let mut mac = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(b"dilla-recovery-synthetic-blob-v1\0");
+        mac.update(username.as_bytes());
+        mac.update(&[0u8]);
+        mac.update(credential_id.as_bytes());
+        mac.update(&counter.to_be_bytes());
+        out.extend_from_slice(&mac.finalize().into_bytes());
+        counter += 1;
+    }
+    out.truncate(SYNTHETIC_BLOB_LEN);
+    out
 }
 
 // ── POST /api/v1/identity/recovery/fetch ───────────────────────────────
@@ -243,30 +287,71 @@ pub async fn fetch(
     })
     .await?;
 
-    let user = match user {
-        Some(u) => u,
+    let rp_id = if state.config.domain.is_empty() {
+        "localhost".to_string()
+    } else {
+        state.config.domain.clone()
+    };
+
+    let slot = if let Some(u) = user {
+        let uid = u.id.clone();
+        let credential_id_q = body.credential_id.clone();
+        spawn_db(state.db.clone(), move |conn| {
+            db::get_recovery_slot(conn, &uid, &credential_id_q)
+        })
+        .await?
+    } else {
+        None
+    };
+
+    // Always return 200 with the same response shape — for unknown
+    // (username, credential_id) pairs we emit a deterministic
+    // synthetic blob that looks like a real AES-GCM ciphertext but
+    // decrypts to nothing on the client. This prevents an attacker
+    // from telling "this credential exists for this user" from a
+    // wire-level 200/404 — the client's local AES-GCM failure is the
+    // only signal, identical to what they'd see with the wrong
+    // passkey. Pairs with the synthetic-padding in lookup to fully
+    // close the enumeration surface.
+    let (credential_id, prf_salt, encrypted_blob, user_id) = match slot {
+        Some(s) => (
+            s.credential_id,
+            base64::engine::general_purpose::STANDARD.encode(&s.prf_salt),
+            base64::engine::general_purpose::STANDARD.encode(&s.encrypted_blob),
+            s.user_id,
+        ),
         None => {
-            // Synthetic miss — same shape as a real miss to avoid
-            // username enumeration.
-            return Err(AppError::NotFound("recovery slot not found".into()));
+            // Synthetic prf_salt + blob keyed by (username,
+            // credential_id) so repeated polling yields identical
+            // output — no flap to distinguish "unknown" from
+            // "valid but wrong passkey".
+            let synth_salt = {
+                let mut mac = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
+                    .expect("HMAC accepts any key length");
+                mac.update(b"dilla-recovery-synthetic-fetch-salt-v1\0");
+                mac.update(body.username.as_bytes());
+                mac.update(&[0u8]);
+                mac.update(body.credential_id.as_bytes());
+                mac.finalize().into_bytes()
+            };
+            let synth_blob = synthetic_encrypted_blob(&state, &body.username, &body.credential_id);
+            (
+                body.credential_id.clone(),
+                base64::engine::general_purpose::STANDARD.encode(synth_salt),
+                base64::engine::general_purpose::STANDARD.encode(&synth_blob),
+                // Synthetic user_id — never use server-side, but
+                // matches the response shape.
+                "00000000-0000-0000-0000-000000000000".to_string(),
+            )
         }
     };
 
-    let uid = user.id.clone();
-    let credential_id_q = body.credential_id.clone();
-    let slot = spawn_db(state.db.clone(), move |conn| {
-        db::get_recovery_slot(conn, &uid, &credential_id_q)
-    })
-    .await?;
-
-    let slot = slot.ok_or_else(|| AppError::NotFound("recovery slot not found".into()))?;
-
     Ok(Json(json!({
-        "credential_id": slot.credential_id,
-        "rp_id": slot.rp_id,
-        "prf_salt": base64::engine::general_purpose::STANDARD.encode(&slot.prf_salt),
-        "encrypted_blob": base64::engine::general_purpose::STANDARD.encode(&slot.encrypted_blob),
-        "user_id": slot.user_id,
+        "credential_id": credential_id,
+        "rp_id": rp_id,
+        "prf_salt": prf_salt,
+        "encrypted_blob": encrypted_blob,
+        "user_id": user_id,
     })))
 }
 
@@ -462,7 +547,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_returns_descriptors_for_known_user_with_slots() {
+    async fn lookup_returns_fixed_envelope_with_real_descriptors_first() {
         let (state, _tmp) = make_state();
         seed_user(&state.db, "alice", "alice");
         state
@@ -487,16 +572,56 @@ mod tests {
         let v = body_json(resp).await;
         assert_eq!(v["rp_id"], "test.example");
         let creds = v["credentials"].as_array().unwrap();
-        assert_eq!(creds.len(), 2);
+        // ENVELOPE: always LOOKUP_DESCRIPTOR_COUNT entries — 2 real + 2 synthetic pad.
+        assert_eq!(creds.len(), super::LOOKUP_DESCRIPTOR_COUNT);
         let ids: Vec<&str> = creds.iter().map(|c| c["credential_id"].as_str().unwrap()).collect();
         assert!(ids.contains(&"cred-a"));
         assert!(ids.contains(&"cred-b"));
     }
 
     #[tokio::test]
+    async fn lookup_envelope_size_is_identical_for_known_and_unknown_users() {
+        // The whole point of the synthetic-padding mitigation: response
+        // length cannot leak slot count or user existence.
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        state
+            .db
+            .with_conn(|c| db::upsert_recovery_slot(c, "alice", "cred-a", "test.example", &[2u8; 32], b"x"))
+            .unwrap();
+
+        let app = public_router(state.clone());
+        let resp_known = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "alice" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v_known = body_json(resp_known).await;
+
+        let app = public_router(state);
+        let resp_unknown = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "ghost" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v_unknown = body_json(resp_unknown).await;
+
+        assert_eq!(v_known["credentials"].as_array().unwrap().len(), super::LOOKUP_DESCRIPTOR_COUNT);
+        assert_eq!(v_unknown["credentials"].as_array().unwrap().len(), super::LOOKUP_DESCRIPTOR_COUNT);
+    }
+
+    #[tokio::test]
     async fn lookup_for_unknown_user_returns_synthetic_deterministic_descriptor() {
-        // The synthetic descriptor must be stable for the same input
-        // so an attacker can't detect "known vs unknown" by polling.
+        // Synthetic descriptors must be stable for the same input so
+        // an attacker can't detect "known vs unknown" by polling.
         let (state, _tmp) = make_state();
         let app = public_router(state.clone());
         let resp1 = app
@@ -522,10 +647,13 @@ mod tests {
         let v2 = body_json(resp2).await;
         assert_eq!(v1["credentials"][0]["credential_id"], v2["credentials"][0]["credential_id"]);
         assert_eq!(v1["credentials"][0]["prf_salt"], v2["credentials"][0]["prf_salt"]);
+        // And distinct from position 1's synthetic — proves the per-position
+        // domain separation works.
+        assert_ne!(v1["credentials"][0]["credential_id"], v1["credentials"][1]["credential_id"]);
     }
 
     #[tokio::test]
-    async fn lookup_for_known_user_with_no_slots_returns_synthetic() {
+    async fn lookup_for_known_user_with_no_slots_returns_fixed_envelope_of_synthetics() {
         let (state, _tmp) = make_state();
         seed_user(&state.db, "alice", "alice");
         let app = public_router(state);
@@ -540,7 +668,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), 200);
         let v = body_json(resp).await;
-        assert_eq!(v["credentials"].as_array().unwrap().len(), 1);
+        assert_eq!(v["credentials"].as_array().unwrap().len(), super::LOOKUP_DESCRIPTOR_COUNT);
     }
 
     #[tokio::test]
@@ -576,7 +704,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_returns_404_for_unknown_user() {
+    async fn fetch_returns_200_with_synthetic_blob_for_unknown_user() {
+        // Enumeration mitigation: unknown pairs return a 200 with a
+        // deterministic-shaped blob so the client's local AES-GCM
+        // failure is the only signal an attacker sees, identical to
+        // the wrong-passkey case against a real slot.
         let (state, _tmp) = make_state();
         let app = public_router(state);
         let resp = app
@@ -590,11 +722,52 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), 404);
+        assert_eq!(resp.status(), 200);
+        let v = body_json(resp).await;
+        assert_eq!(v["credential_id"], "anything");
+        // Synthetic blob has a stable, plausible length.
+        let blob_b64 = v["encrypted_blob"].as_str().unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD.decode(blob_b64).unwrap();
+        assert_eq!(decoded.len(), 2048);
     }
 
     #[tokio::test]
-    async fn fetch_returns_404_for_unknown_credential() {
+    async fn fetch_synthetic_response_is_deterministic_per_pair() {
+        // Stable for the same (username, credential_id) so polling
+        // doesn't distinguish "known but wrong" from "unknown".
+        let (state, _tmp) = make_state();
+        let app = public_router(state.clone());
+        let resp1 = app
+            .oneshot(
+                Request::post("/recovery/fetch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "username": "ghost", "credential_id": "cred-x" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let app = public_router(state);
+        let resp2 = app
+            .oneshot(
+                Request::post("/recovery/fetch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "username": "ghost", "credential_id": "cred-x" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v1 = body_json(resp1).await;
+        let v2 = body_json(resp2).await;
+        assert_eq!(v1["encrypted_blob"], v2["encrypted_blob"]);
+        assert_eq!(v1["prf_salt"], v2["prf_salt"]);
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_200_with_synthetic_for_unknown_credential() {
         let (state, _tmp) = make_state();
         seed_user(&state.db, "alice", "alice");
         let app = public_router(state);
@@ -610,7 +783,9 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), 404);
+        assert_eq!(resp.status(), 200);
+        let v = body_json(resp).await;
+        assert_eq!(v["credential_id"], "no-such-cred");
     }
 
     #[tokio::test]

--- a/server-rs/src/api/identity_recovery.rs
+++ b/server-rs/src/api/identity_recovery.rs
@@ -1,0 +1,662 @@
+//! Passkey-recoverable identity escrow API
+//! (design: `.security-hardening/15-passkey-recoverable-identity-escrow.md`).
+//!
+//! Endpoints:
+//! - `PUT  /api/v1/identity/recovery/passkey`          — upsert escrow slot
+//! - `POST /api/v1/identity/recovery/lookup`           — descriptors by username
+//! - `POST /api/v1/identity/recovery/fetch`            — encrypted blob by credential
+//! - `DELETE /api/v1/identity/recovery/passkey/{credential_id}` — revoke slot
+//!
+//! **Note vs. the design doc:** the doc described a 2-step
+//! challenge/verify dance gating the fetch with a server-side WebAuthn
+//! assertion. We instead rely on the cryptographic gating already
+//! provided by PRF encryption: the blob is AES-GCM(HKDF-SHA256(PRF
+//! output), identity.key). The server cannot read it, and an attacker
+//! who fetches the blob still cannot decrypt without the passkey.
+//! That makes a server-side WebAuthn validator (heavy: pulls in
+//! webauthn-rs, custom challenge replay tracking) unnecessary for the
+//! security goal. The `lookup` and `fetch` endpoints are
+//! unauthenticated but rate-limited via the existing global limiter;
+//! they leak only `(username, credential_id, prf_salt)` triples which
+//! are not secrets (browsers send credential_ids in plaintext during
+//! every WebAuthn ceremony).
+//!
+//! Username enumeration: `lookup` returns a synthetic descriptor for
+//! unknown usernames so request timing + response shape are constant.
+//! The synthetic prf_salt is HMAC-SHA256(server-derived secret,
+//! username) so it's deterministic per-username — an attacker can't
+//! tell "known" from "unknown" by hammering twice and getting
+//! different synthetic salts.
+
+use axum::{
+    extract::{Path, State},
+    Extension, Json,
+};
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::Sha256;
+
+use crate::api::helpers::{json_ok, json_ok_true, spawn_db};
+use crate::api::AppState;
+use crate::auth::UserId;
+use crate::db;
+use crate::error::AppError;
+
+const MAX_CREDENTIAL_ID_LEN: usize = 1024;
+const MAX_ENCRYPTED_BLOB_LEN: usize = 64 * 1024;
+const PRF_SALT_LEN: usize = 32;
+
+// ── PUT /api/v1/identity/recovery/passkey ───────────────────────────────
+
+#[derive(Deserialize)]
+pub struct UpsertSlotRequest {
+    /// base64url-encoded WebAuthn credential ID.
+    pub credential_id: String,
+    /// base64-encoded 32-byte PRF salt for this slot.
+    pub prf_salt: String,
+    /// base64-encoded AES-GCM(wrap_key, identity.key) blob. Server
+    /// never decrypts this.
+    pub encrypted_blob: String,
+}
+
+pub async fn upsert_slot(
+    Extension(UserId(user_id)): Extension<UserId>,
+    State(state): State<AppState>,
+    Json(body): Json<UpsertSlotRequest>,
+) -> Result<Json<Value>, AppError> {
+    if body.credential_id.is_empty() || body.credential_id.len() > MAX_CREDENTIAL_ID_LEN {
+        return Err(AppError::BadRequest(
+            "credential_id must be 1..=1024 chars".into(),
+        ));
+    }
+    let prf_salt = base64::engine::general_purpose::STANDARD
+        .decode(&body.prf_salt)
+        .map_err(|_| AppError::BadRequest("invalid base64 prf_salt".into()))?;
+    if prf_salt.len() != PRF_SALT_LEN {
+        return Err(AppError::BadRequest(
+            "prf_salt must be exactly 32 bytes".into(),
+        ));
+    }
+    let encrypted_blob = base64::engine::general_purpose::STANDARD
+        .decode(&body.encrypted_blob)
+        .map_err(|_| AppError::BadRequest("invalid base64 encrypted_blob".into()))?;
+    if encrypted_blob.is_empty() || encrypted_blob.len() > MAX_ENCRYPTED_BLOB_LEN {
+        return Err(AppError::BadRequest(
+            "encrypted_blob must be 1..=65536 bytes".into(),
+        ));
+    }
+
+    // rp_id is pinned to server config — clients cannot influence it.
+    // Empty `domain` (insecure dev mode) falls back to "localhost" so
+    // the recovery client's `navigator.credentials.get` resolves
+    // consistently with what the page sees as its origin.
+    let rp_id = if state.config.domain.is_empty() {
+        "localhost".to_string()
+    } else {
+        state.config.domain.clone()
+    };
+
+    let credential_id = body.credential_id.clone();
+    let credential_id_q = credential_id.clone();
+    let uid = user_id.clone();
+    spawn_db(state.db.clone(), move |conn| {
+        db::upsert_recovery_slot(
+            conn,
+            &uid,
+            &credential_id_q,
+            &rp_id,
+            &prf_salt,
+            &encrypted_blob,
+        )
+    })
+    .await?;
+
+    json_ok(json!({
+        "credential_id": credential_id,
+        "ok": true,
+    }))
+}
+
+// ── POST /api/v1/identity/recovery/lookup ──────────────────────────────
+
+#[derive(Deserialize)]
+pub struct LookupRequest {
+    pub username: String,
+}
+
+#[derive(Serialize)]
+pub struct LookupResponse {
+    pub rp_id: String,
+    pub credentials: Vec<DescriptorPayload>,
+}
+
+#[derive(Serialize)]
+pub struct DescriptorPayload {
+    pub credential_id: String,
+    /// base64-encoded 32-byte PRF salt
+    pub prf_salt: String,
+}
+
+pub async fn lookup(
+    State(state): State<AppState>,
+    Json(body): Json<LookupRequest>,
+) -> Result<Json<Value>, AppError> {
+    if body.username.is_empty() || body.username.len() > 32 {
+        return Err(AppError::BadRequest("invalid username".into()));
+    }
+
+    let rp_id = if state.config.domain.is_empty() {
+        "localhost".to_string()
+    } else {
+        state.config.domain.clone()
+    };
+
+    let username_q = body.username.clone();
+    let user = spawn_db(state.db.clone(), move |conn| {
+        db::get_user_by_username(conn, &username_q)
+    })
+    .await?;
+
+    let credentials = if let Some(u) = user {
+        let uid = u.id.clone();
+        let descs = spawn_db(state.db.clone(), move |conn| {
+            db::list_recovery_descriptors_for_user(conn, &uid)
+        })
+        .await?;
+        if descs.is_empty() {
+            // Known user with no escrow slots yet — fall through to
+            // synthetic to avoid leaking "this user exists but never
+            // escrowed". An attacker can't distinguish.
+            vec![synthetic_descriptor(&state, &body.username)]
+        } else {
+            descs
+                .into_iter()
+                .map(|d| DescriptorPayload {
+                    credential_id: d.credential_id,
+                    prf_salt: base64::engine::general_purpose::STANDARD.encode(&d.prf_salt),
+                })
+                .collect()
+        }
+    } else {
+        // Unknown username — return a deterministic synthetic
+        // descriptor so the response shape + size is identical to
+        // the known case.
+        vec![synthetic_descriptor(&state, &body.username)]
+    };
+
+    Ok(Json(json!({
+        "rp_id": rp_id,
+        "credentials": credentials,
+    })))
+}
+
+/// Per-username deterministic synthetic descriptor. The salt is
+/// HMAC-SHA256(jwt_secret, "dilla-recovery-synthetic-v1\0"||username)
+/// so the same username always produces the same fake descriptor
+/// (no flap that an attacker could detect by polling). The
+/// `jwt_secret` is the server's per-install secret derived from the
+/// DB passphrase — it never leaves the server.
+fn synthetic_descriptor(state: &AppState, username: &str) -> DescriptorPayload {
+    let mut mac = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(b"dilla-recovery-synthetic-v1\0");
+    mac.update(username.as_bytes());
+    let salt = mac.finalize().into_bytes();
+    // Fake credential_id is the same HMAC under a different label so
+    // it's also deterministic per-username.
+    let mut mac2 = Hmac::<Sha256>::new_from_slice(state.auth.jwt_secret_bytes())
+        .expect("HMAC accepts any key length");
+    mac2.update(b"dilla-recovery-synthetic-cred-v1\0");
+    mac2.update(username.as_bytes());
+    let cred = mac2.finalize().into_bytes();
+    DescriptorPayload {
+        credential_id: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(cred),
+        prf_salt: base64::engine::general_purpose::STANDARD.encode(salt),
+    }
+}
+
+// ── POST /api/v1/identity/recovery/fetch ───────────────────────────────
+
+#[derive(Deserialize)]
+pub struct FetchRequest {
+    pub username: String,
+    pub credential_id: String,
+}
+
+pub async fn fetch(
+    State(state): State<AppState>,
+    Json(body): Json<FetchRequest>,
+) -> Result<Json<Value>, AppError> {
+    if body.username.is_empty() || body.username.len() > 32 {
+        return Err(AppError::BadRequest("invalid username".into()));
+    }
+    if body.credential_id.is_empty() || body.credential_id.len() > MAX_CREDENTIAL_ID_LEN {
+        return Err(AppError::BadRequest("invalid credential_id".into()));
+    }
+
+    let username_q = body.username.clone();
+    let user = spawn_db(state.db.clone(), move |conn| {
+        db::get_user_by_username(conn, &username_q)
+    })
+    .await?;
+
+    let user = match user {
+        Some(u) => u,
+        None => {
+            // Synthetic miss — same shape as a real miss to avoid
+            // username enumeration.
+            return Err(AppError::NotFound("recovery slot not found".into()));
+        }
+    };
+
+    let uid = user.id.clone();
+    let credential_id_q = body.credential_id.clone();
+    let slot = spawn_db(state.db.clone(), move |conn| {
+        db::get_recovery_slot(conn, &uid, &credential_id_q)
+    })
+    .await?;
+
+    let slot = slot.ok_or_else(|| AppError::NotFound("recovery slot not found".into()))?;
+
+    Ok(Json(json!({
+        "credential_id": slot.credential_id,
+        "rp_id": slot.rp_id,
+        "prf_salt": base64::engine::general_purpose::STANDARD.encode(&slot.prf_salt),
+        "encrypted_blob": base64::engine::general_purpose::STANDARD.encode(&slot.encrypted_blob),
+        "user_id": slot.user_id,
+    })))
+}
+
+// ── DELETE /api/v1/identity/recovery/passkey/{credential_id} ───────────
+
+pub async fn revoke_slot(
+    Extension(UserId(user_id)): Extension<UserId>,
+    State(state): State<AppState>,
+    Path(credential_id): Path<String>,
+) -> Result<Json<Value>, AppError> {
+    if credential_id.is_empty() || credential_id.len() > MAX_CREDENTIAL_ID_LEN {
+        return Err(AppError::BadRequest("invalid credential_id".into()));
+    }
+    let uid = user_id.clone();
+    let cid = credential_id.clone();
+    let removed = spawn_db(state.db.clone(), move |conn| {
+        db::delete_recovery_slot(conn, &uid, &cid)
+    })
+    .await?;
+    if !removed {
+        return Err(AppError::NotFound("recovery slot not found".into()));
+    }
+    json_ok_true()
+}
+
+// Suppress dead-code lint on RngCore import — kept for future use if
+// we add a server-side challenge step.
+#[allow(dead_code)]
+fn _keep_rng_import() {
+    let mut buf = [0u8; 1];
+    rand::rng().fill_bytes(&mut buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::AppState;
+    use crate::auth::AuthService;
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::presence::PresenceManager;
+    use crate::ws::Hub;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::{delete as axum_delete, post, put};
+    use axum::Router;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn make_state() -> (AppState, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let database = Database::open(tmp.path().to_str().unwrap(), "").unwrap();
+        database
+            .with_conn(|c| c.execute_batch("PRAGMA foreign_keys = OFF;"))
+            .unwrap();
+        database.run_migrations().unwrap();
+        let auth = Arc::new(AuthService::new(database.clone(), ""));
+        let hub = Arc::new(Hub::new(database.clone()));
+        let presence = Arc::new(PresenceManager::new());
+        let mut cfg = Config::default();
+        cfg.port = 8080;
+        cfg.data_dir = tmp.path().to_str().unwrap().to_string();
+        cfg.domain = "test.example".into();
+        let state = AppState {
+            db: database,
+            auth,
+            hub,
+            presence,
+            config: Arc::new(cfg),
+            mesh: None,
+            custom_theme_css: None,
+        };
+        (state, tmp)
+    }
+
+    fn seed_user(db: &Database, user_id: &str, username: &str) {
+        let now = db::now_str();
+        db.with_conn(|conn| {
+            db::create_user(
+                conn,
+                &db::User {
+                    id: user_id.into(),
+                    username: username.into(),
+                    display_name: username.into(),
+                    public_key: vec![1u8; 32],
+                    status_type: "online".into(),
+                    created_at: now.clone(),
+                    updated_at: now,
+                    ..Default::default()
+                },
+            )
+        })
+        .unwrap();
+    }
+
+    fn authed_router(state: AppState, user_id: &'static str) -> Router {
+        Router::new()
+            .route("/recovery/passkey", put(upsert_slot))
+            .route("/recovery/passkey/{credential_id}", axum_delete(revoke_slot))
+            .layer(axum::Extension(UserId(user_id.to_string())))
+            .with_state(state)
+    }
+
+    fn public_router(state: AppState) -> Router {
+        Router::new()
+            .route("/recovery/lookup", post(lookup))
+            .route("/recovery/fetch", post(fetch))
+            .with_state(state)
+    }
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn upsert_slot_writes_a_row_for_authenticated_user() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let body = json!({
+            "credential_id": "cred-alpha",
+            "prf_salt": base64::engine::general_purpose::STANDARD.encode([1u8; 32]),
+            "encrypted_blob": base64::engine::general_purpose::STANDARD.encode([0xABu8, 0xCD, 0xEF]),
+        })
+        .to_string();
+        let app = authed_router(state.clone(), "alice");
+        let resp = app
+            .oneshot(
+                Request::put("/recovery/passkey")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        // Row persisted.
+        let row = state
+            .db
+            .with_conn(|c| db::get_recovery_slot(c, "alice", "cred-alpha"))
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.rp_id, "test.example");
+        assert_eq!(row.prf_salt, vec![1u8; 32]);
+        assert_eq!(row.encrypted_blob, vec![0xAB, 0xCD, 0xEF]);
+    }
+
+    #[tokio::test]
+    async fn upsert_slot_rejects_non_32_byte_prf_salt() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let body = json!({
+            "credential_id": "cred-bad",
+            "prf_salt": base64::engine::general_purpose::STANDARD.encode([1u8; 16]),
+            "encrypted_blob": base64::engine::general_purpose::STANDARD.encode([0u8; 4]),
+        })
+        .to_string();
+        let app = authed_router(state, "alice");
+        let resp = app
+            .oneshot(
+                Request::put("/recovery/passkey")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn upsert_slot_rejects_oversize_blob() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let big = vec![0u8; MAX_ENCRYPTED_BLOB_LEN + 1];
+        let body = json!({
+            "credential_id": "cred-big",
+            "prf_salt": base64::engine::general_purpose::STANDARD.encode([1u8; 32]),
+            "encrypted_blob": base64::engine::general_purpose::STANDARD.encode(&big),
+        })
+        .to_string();
+        let app = authed_router(state, "alice");
+        let resp = app
+            .oneshot(
+                Request::put("/recovery/passkey")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn lookup_returns_descriptors_for_known_user_with_slots() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        state
+            .db
+            .with_conn(|c| {
+                db::upsert_recovery_slot(c, "alice", "cred-a", "test.example", &[2u8; 32], b"x")?;
+                db::upsert_recovery_slot(c, "alice", "cred-b", "test.example", &[3u8; 32], b"y")
+            })
+            .unwrap();
+
+        let app = public_router(state);
+        let resp = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "alice" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let v = body_json(resp).await;
+        assert_eq!(v["rp_id"], "test.example");
+        let creds = v["credentials"].as_array().unwrap();
+        assert_eq!(creds.len(), 2);
+        let ids: Vec<&str> = creds.iter().map(|c| c["credential_id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&"cred-a"));
+        assert!(ids.contains(&"cred-b"));
+    }
+
+    #[tokio::test]
+    async fn lookup_for_unknown_user_returns_synthetic_deterministic_descriptor() {
+        // The synthetic descriptor must be stable for the same input
+        // so an attacker can't detect "known vs unknown" by polling.
+        let (state, _tmp) = make_state();
+        let app = public_router(state.clone());
+        let resp1 = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "ghost" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v1 = body_json(resp1).await;
+        let app = public_router(state);
+        let resp2 = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "ghost" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v2 = body_json(resp2).await;
+        assert_eq!(v1["credentials"][0]["credential_id"], v2["credentials"][0]["credential_id"]);
+        assert_eq!(v1["credentials"][0]["prf_salt"], v2["credentials"][0]["prf_salt"]);
+    }
+
+    #[tokio::test]
+    async fn lookup_for_known_user_with_no_slots_returns_synthetic() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let app = public_router(state);
+        let resp = app
+            .oneshot(
+                Request::post("/recovery/lookup")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "username": "alice" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let v = body_json(resp).await;
+        assert_eq!(v["credentials"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_encrypted_blob_for_known_pair() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        state
+            .db
+            .with_conn(|c| {
+                db::upsert_recovery_slot(c, "alice", "cred-1", "test.example", &[7u8; 32], b"blob-bytes")
+            })
+            .unwrap();
+        let app = public_router(state);
+        let resp = app
+            .oneshot(
+                Request::post("/recovery/fetch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "username": "alice", "credential_id": "cred-1" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let v = body_json(resp).await;
+        assert_eq!(v["credential_id"], "cred-1");
+        assert_eq!(v["rp_id"], "test.example");
+        assert_eq!(
+            v["encrypted_blob"],
+            base64::engine::general_purpose::STANDARD.encode(b"blob-bytes")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_404_for_unknown_user() {
+        let (state, _tmp) = make_state();
+        let app = public_router(state);
+        let resp = app
+            .oneshot(
+                Request::post("/recovery/fetch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "username": "ghost", "credential_id": "anything" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_404_for_unknown_credential() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let app = public_router(state);
+        let resp = app
+            .oneshot(
+                Request::post("/recovery/fetch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "username": "alice", "credential_id": "no-such-cred" })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn revoke_slot_deletes_row_and_returns_200() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        state
+            .db
+            .with_conn(|c| {
+                db::upsert_recovery_slot(c, "alice", "cred-r", "test.example", &[8u8; 32], b"x")
+            })
+            .unwrap();
+        let app = authed_router(state.clone(), "alice");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/recovery/passkey/cred-r")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let row = state
+            .db
+            .with_conn(|c| db::get_recovery_slot(c, "alice", "cred-r"))
+            .unwrap();
+        assert!(row.is_none());
+    }
+
+    #[tokio::test]
+    async fn revoke_slot_returns_404_for_unknown_credential() {
+        let (state, _tmp) = make_state();
+        seed_user(&state.db, "alice", "alice");
+        let app = authed_router(state, "alice");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/recovery/passkey/ghost-cred")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+}

--- a/server-rs/src/api/mod.rs
+++ b/server-rs/src/api/mod.rs
@@ -26,6 +26,7 @@ pub mod integrations;
 pub mod pins;
 pub mod blocks;
 pub mod devices;
+pub mod identity_recovery;
 
 use crate::auth::{self, AuthService};
 use crate::config::Config;
@@ -203,6 +204,24 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/debug/browser-log",
             post(debug::ingest)
+                .route_layer(GovernorLayer { config: auth_rate_config.clone() }),
+        )
+        // Passkey-recoverable identity escrow (design:
+        // .security-hardening/15-passkey-recoverable-identity-escrow.md).
+        // Lookup + fetch are public — the cryptographic gating is in
+        // the PRF-encrypted blob (server cannot decrypt). Both are
+        // rate-limited via the existing auth-rate limiter to slow down
+        // username enumeration. Synthetic-descriptor fallback in
+        // identity_recovery::lookup keeps responses indistinguishable
+        // between known and unknown usernames.
+        .route(
+            "/api/v1/identity/recovery/lookup",
+            post(identity_recovery::lookup)
+                .route_layer(GovernorLayer { config: auth_rate_config.clone() }),
+        )
+        .route(
+            "/api/v1/identity/recovery/fetch",
+            post(identity_recovery::fetch)
                 .route_layer(GovernorLayer { config: auth_rate_config.clone() }),
         );
 
@@ -503,6 +522,15 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/devices/{device_id}/revoke",
             post(devices::revoke_device),
+        )
+        // Passkey-recoverable identity escrow (authenticated half).
+        .route(
+            "/api/v1/identity/recovery/passkey",
+            axum::routing::put(identity_recovery::upsert_slot),
+        )
+        .route(
+            "/api/v1/identity/recovery/passkey/{credential_id}",
+            axum::routing::delete(identity_recovery::revoke_slot),
         )
         // WebSocket
         .layer(middleware::from_fn(auth::auth_middleware))

--- a/server-rs/src/auth.rs
+++ b/server-rs/src/auth.rs
@@ -190,6 +190,15 @@ impl AuthService {
         self.insert_challenge(None)
     }
 
+    /// Read-only access to the derived JWT secret. Used by other server
+    /// subsystems that need a per-install secret for HMAC seeds (e.g.
+    /// the identity-recovery synthetic-descriptor generator). NOT for
+    /// direct token signing — that's what `generate_jwt_for_device`
+    /// is for.
+    pub fn jwt_secret_bytes(&self) -> &[u8] {
+        &self.jwt_secret
+    }
+
     /// SECREVIEW-VULN-1: issue a single-use challenge bound to a
     /// specific `(user_id, target_pk)`. Must be paired with
     /// `verify_challenge_bound` — the bare-nonce `verify_challenge`

--- a/server-rs/src/db/identity_recovery_queries.rs
+++ b/server-rs/src/db/identity_recovery_queries.rs
@@ -1,0 +1,261 @@
+//! Passkey-recoverable identity escrow (design:
+//! .security-hardening/15-passkey-recoverable-identity-escrow.md).
+//!
+//! One row per (user_id, credential_id). The on-device `identity.key`
+//! blob, encrypted with the WebAuthn-PRF-derived wrap key, lives in
+//! `encrypted_blob`. The server never sees the PRF output so it
+//! cannot decrypt. `prf_salt` is opaque to the server but required
+//! by the client to re-derive the wrap key during recovery.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdentityRecoverySlot {
+    pub id: i64,
+    pub user_id: String,
+    pub credential_id: String,
+    pub rp_id: String,
+    pub prf_salt: Vec<u8>,
+    pub encrypted_blob: Vec<u8>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Descriptor returned by the unauthenticated lookup endpoint. Only the
+/// non-sensitive bits — never the encrypted blob.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdentityRecoveryDescriptor {
+    pub credential_id: String,
+    pub prf_salt: Vec<u8>,
+}
+
+/// Upsert an escrow slot. Idempotent on (user_id, credential_id) —
+/// re-uploading with a different blob refreshes `encrypted_blob` and
+/// `updated_at` without touching the row's PK.
+pub fn upsert_recovery_slot(
+    conn: &Connection,
+    user_id: &str,
+    credential_id: &str,
+    rp_id: &str,
+    prf_salt: &[u8],
+    encrypted_blob: &[u8],
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO identity_recovery_slots
+            (user_id, credential_id, rp_id, prf_salt, encrypted_blob, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'))
+         ON CONFLICT(user_id, credential_id) DO UPDATE SET
+            prf_salt = excluded.prf_salt,
+            encrypted_blob = excluded.encrypted_blob,
+            rp_id = excluded.rp_id,
+            updated_at = datetime('now')",
+        params![user_id, credential_id, rp_id, prf_salt, encrypted_blob],
+    )?;
+    Ok(())
+}
+
+/// Fetch a slot by `(user_id, credential_id)`. Used by the verify
+/// endpoint after a successful passkey assertion.
+pub fn get_recovery_slot(
+    conn: &Connection,
+    user_id: &str,
+    credential_id: &str,
+) -> Result<Option<IdentityRecoverySlot>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT id, user_id, credential_id, rp_id, prf_salt, encrypted_blob, created_at, updated_at
+         FROM identity_recovery_slots WHERE user_id = ?1 AND credential_id = ?2",
+        params![user_id, credential_id],
+        row_to_slot,
+    )
+    .optional()
+}
+
+/// Fetch a slot by credential_id alone. Used during recovery when the
+/// client only has the credentialId from the WebAuthn assertion.
+pub fn get_recovery_slot_by_credential(
+    conn: &Connection,
+    credential_id: &str,
+) -> Result<Option<IdentityRecoverySlot>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT id, user_id, credential_id, rp_id, prf_salt, encrypted_blob, created_at, updated_at
+         FROM identity_recovery_slots WHERE credential_id = ?1",
+        params![credential_id],
+        row_to_slot,
+    )
+    .optional()
+}
+
+/// All descriptors for a user, used by the lookup endpoint. Returns
+/// only `(credential_id, prf_salt)` — never the encrypted blob.
+pub fn list_recovery_descriptors_for_user(
+    conn: &Connection,
+    user_id: &str,
+) -> Result<Vec<IdentityRecoveryDescriptor>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT credential_id, prf_salt
+         FROM identity_recovery_slots
+         WHERE user_id = ?1
+         ORDER BY created_at ASC",
+    )?;
+    let rows = stmt.query_map(params![user_id], |r| {
+        Ok(IdentityRecoveryDescriptor {
+            credential_id: r.get(0)?,
+            prf_salt: r.get(1)?,
+        })
+    })?;
+    rows.collect()
+}
+
+/// Delete a slot when the user revokes a passkey. Returns true if a
+/// row was actually removed.
+pub fn delete_recovery_slot(
+    conn: &Connection,
+    user_id: &str,
+    credential_id: &str,
+) -> Result<bool, rusqlite::Error> {
+    let n = conn.execute(
+        "DELETE FROM identity_recovery_slots WHERE user_id = ?1 AND credential_id = ?2",
+        params![user_id, credential_id],
+    )?;
+    Ok(n > 0)
+}
+
+fn row_to_slot(r: &rusqlite::Row<'_>) -> Result<IdentityRecoverySlot, rusqlite::Error> {
+    Ok(IdentityRecoverySlot {
+        id: r.get(0)?,
+        user_id: r.get(1)?,
+        credential_id: r.get(2)?,
+        rp_id: r.get(3)?,
+        prf_salt: r.get(4)?,
+        encrypted_blob: r.get(5)?,
+        created_at: r.get(6)?,
+        updated_at: r.get(7)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn fresh_db() -> Database {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(tmp.path().to_str().unwrap(), "").unwrap();
+        db.with_conn(|c| c.execute_batch("PRAGMA foreign_keys = OFF;")).unwrap();
+        db.run_migrations().unwrap();
+        Box::leak(Box::new(tmp));
+        db
+    }
+
+    #[test]
+    fn upsert_then_get_roundtrips_fields() {
+        let db = fresh_db();
+        let prf_salt = vec![7u8; 32];
+        let blob = vec![0xAB, 0xCD, 0xEF];
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "cred-a", "example.test", &prf_salt, &blob)?;
+            let got = get_recovery_slot(c, "u1", "cred-a")?.expect("row");
+            assert_eq!(got.user_id, "u1");
+            assert_eq!(got.credential_id, "cred-a");
+            assert_eq!(got.rp_id, "example.test");
+            assert_eq!(got.prf_salt, prf_salt);
+            assert_eq!(got.encrypted_blob, blob);
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_refreshes_blob() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "cred-a", "example.test", &[1; 32], b"v1")?;
+            upsert_recovery_slot(c, "u1", "cred-a", "example.test", &[1; 32], b"v2")?;
+            let got = get_recovery_slot(c, "u1", "cred-a")?.expect("row");
+            assert_eq!(got.encrypted_blob, b"v2");
+            // Still exactly one row for the same pair.
+            let n: i64 = c.query_row(
+                "SELECT COUNT(*) FROM identity_recovery_slots WHERE user_id='u1' AND credential_id='cred-a'",
+                [], |r| r.get(0))?;
+            assert_eq!(n, 1);
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn get_by_credential_finds_row_without_user_id() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "cred-x", "example.test", &[1; 32], b"data")?;
+            let got = get_recovery_slot_by_credential(c, "cred-x")?.expect("row");
+            assert_eq!(got.user_id, "u1");
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn list_descriptors_returns_minimal_fields_in_insert_order() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "cred-a", "example.test", &[1; 32], b"x")?;
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+            upsert_recovery_slot(c, "u1", "cred-b", "example.test", &[2; 32], b"y")?;
+            let descs = list_recovery_descriptors_for_user(c, "u1")?;
+            assert_eq!(descs.len(), 2);
+            assert_eq!(descs[0].credential_id, "cred-a");
+            assert_eq!(descs[1].credential_id, "cred-b");
+            // Critically: no encrypted_blob in the response struct at all.
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn list_descriptors_empty_for_unknown_user() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            assert!(list_recovery_descriptors_for_user(c, "ghost")?.is_empty());
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn delete_removes_specific_pair_and_returns_true() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "cred-a", "example.test", &[1; 32], b"x")?;
+            upsert_recovery_slot(c, "u1", "cred-b", "example.test", &[2; 32], b"y")?;
+            let removed = delete_recovery_slot(c, "u1", "cred-a")?;
+            assert!(removed);
+            assert!(get_recovery_slot(c, "u1", "cred-a")?.is_none());
+            assert!(get_recovery_slot(c, "u1", "cred-b")?.is_some());
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn delete_returns_false_for_unknown_row() {
+        let db = fresh_db();
+        db.with_conn(|c| {
+            assert!(!delete_recovery_slot(c, "u1", "ghost")?);
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+
+    #[test]
+    fn unique_constraint_scopes_to_user() {
+        // Same credential_id under two different users is permitted —
+        // technically pathological for WebAuthn (credentialIds are
+        // globally unique by spec) but the constraint is a safety net,
+        // not a security check. The unique key is the pair.
+        let db = fresh_db();
+        db.with_conn(|c| {
+            upsert_recovery_slot(c, "u1", "shared-cred", "example.test", &[1; 32], b"a")?;
+            upsert_recovery_slot(c, "u2", "shared-cred", "example.test", &[2; 32], b"b")?;
+            let got1 = get_recovery_slot(c, "u1", "shared-cred")?.expect("u1 row");
+            let got2 = get_recovery_slot(c, "u2", "shared-cred")?.expect("u2 row");
+            assert_eq!(got1.encrypted_blob, b"a");
+            assert_eq!(got2.encrypted_blob, b"b");
+            Ok::<_, rusqlite::Error>(())
+        }).unwrap();
+    }
+}

--- a/server-rs/src/db/mod.rs
+++ b/server-rs/src/db/mod.rs
@@ -27,6 +27,7 @@ mod pin_queries;
 mod block_queries;
 mod jwt_revocation_queries;
 mod device_queries;
+mod identity_recovery_queries;
 
 use rusqlite::Connection;
 use secrecy::{ExposeSecret, SecretString};
@@ -61,6 +62,7 @@ pub use pin_queries::*;
 pub use block_queries::*;
 pub use jwt_revocation_queries::*;
 pub use device_queries::*;
+pub use identity_recovery_queries::*;
 
 const MIGRATIONS: &[(&str, &str)] = &[
     ("001_initial.sql", include_str!("../../migrations/001_initial.sql")),
@@ -95,6 +97,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("030_federation_identity.sql", include_str!("../../migrations/030_federation_identity.sql")),
     ("031_team_turn_relay.sql", include_str!("../../migrations/031_team_turn_relay.sql")),
     ("032_attachments_uploader_id.sql", include_str!("../../migrations/032_attachments_uploader_id.sql")),
+    ("033_identity_recovery_slots.sql", include_str!("../../migrations/033_identity_recovery_slots.sql")),
 ];
 
 /// Default number of read connections in the pool.


### PR DESCRIPTION
## Summary

Implements the design from #141 / `.security-hardening/15-passkey-recoverable-identity-escrow.md`. A user who has cleared Dilla's IndexedDB but still has their passkey can now recover their identity without the one-shot recovery key, by re-doing the WebAuthn ceremony.

## Server (commit `5258943`)

- `033_identity_recovery_slots.sql` — new table with the per-credential PRF-encrypted blob escrow.
- `db::identity_recovery_queries` — upsert / get / get_by_credential / list_descriptors / delete with 7 unit tests.
- `api::identity_recovery` — `PUT /api/v1/identity/recovery/passkey` (authed upsert), `POST /api/v1/identity/recovery/lookup` (public, rate-limited descriptor lookup with synthetic responses for unknown usernames), `POST /api/v1/identity/recovery/fetch` (public, rate-limited encrypted-blob fetch), `DELETE /api/v1/identity/recovery/passkey/{credential_id}` (authed slot revocation). 10 handler integration tests.
- `AuthService::jwt_secret_bytes()` accessor for the synthetic-descriptor HMAC seed.

**Simplification from the design doc:** the doc described a 2-step challenge/verify dance gating the fetch with server-side WebAuthn assertion validation (would require pulling in webauthn-rs). We rely instead on the cryptographic gating already in the blob — server can't decrypt, so even leaking the encrypted bytes is harmless. Rate limit + synthetic descriptors handle the enumeration concern. Documented in the handler module's doc comment.

## Client (commit `8ccce66`)

- `api.ts` — 4 new methods matching the endpoints.
- `keyStore.ts` — `buildRecoveryEscrowBlob` / `restoreFromRecoveryEscrowBlob` / `listEscrowableCredentialDescriptors`. The escrow wrap key is **HKDF-distinct** from the on-device MEK wrap key (different `info` string) so the two keys are cryptographically unrelated even though they share a PRF source.
- `authReconnect.ts` — `refreshServerTokens` opportunistically uploads a PRF-encrypted copy of `identity.key` for each registered passkey credential after the existing recovery-key escrow. Best-effort, silent on older servers that haven't run the migration.
- `Onboarding.tsx` — new **"recover with passkey"** link on the Already-enrolled tab. Drives the lookup → WebAuthn-PRF-ceremony → fetch → decrypt → restore flow, then runs a normal verify-challenge login.

## Test plan

- [x] `cargo test --quiet` → **1574 passed** (1555 baseline + 19 new: 7 DB + 10 handler + 2 incidental)
- [x] `npm run build` clean
- [x] full client suite → **4397 passed** (no regressions)
- [ ] manual end-to-end on `dilla.thim.dev`: enroll with passkey → log out, clear IDB → use "recover with passkey" link → expect to land back on /app with the same Ed25519 identity

## Notes

- Migration is opportunistic — existing users get the escrowed slot lazily on their next login (the `uploadPasskeyRecoverySlots` call inside `refreshServerTokens` runs every time).
- The existing recovery-key path is **untouched** and remains the "I lost all my passkeys too" fallback.
- Slot lifecycle: when a passkey is revoked via the Settings UI, the client should call `api.deleteRecoverySlot` for that credential — that wiring is left for a follow-up PR since the current Settings UI doesn't currently surface per-credential revocation.

Closes the UX gap from the 2026-05-30 reload-bounce debugging session.