### PR TITLE
fix(onboarding): single passkey prompt + base64url IDs for recovery

### DIFF
--- a/client/src/pages/Onboarding/Onboarding.flows.test.tsx
+++ b/client/src/pages/Onboarding/Onboarding.flows.test.tsx
@@ -71,6 +71,20 @@ const webauthnMock = vi.hoisted(() => ({
   authenticatePasskey: vi.fn(async () => ({ prfOutput: new ArrayBuffer(32) })),
   prfOutputToBase64: vi.fn(() => 'prf-b64'),
   decodeRecoveryKey: vi.fn(() => new Uint8Array(32)),
+  arrayBufferToBase64Url: vi.fn((buf: ArrayBuffer) => {
+    const bytes = new Uint8Array(buf);
+    let bin = '';
+    for (const b of bytes) bin += String.fromCodePoint(b);
+    return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+  }),
+  base64UrlToArrayBuffer: vi.fn((s: string) => {
+    const b64 = s.replaceAll('-', '+').replaceAll('_', '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out.buffer;
+  }),
 }));
 vi.mock('../../services/webauthn', () => webauthnMock);
 
@@ -220,9 +234,18 @@ describe('Onboarding doConnect — passkey recovery sub-flow (design doc 15)', (
   // shape closely enough that runPasskeyRecoveryFlow's PRF extraction
   // path runs through to the api.fetchRecoveryBlob call.
   beforeEach(() => {
+    // assertion.rawId is decoded back to base64url by the flow to look
+    // up the matching descriptor, so it must round-trip to the same
+    // credential_id the mocked lookupRecoveryDescriptors returns. The
+    // bytes here decode to the same value as base64url-decoding
+    // 'cred-r1' would (atob('cred+r1=')).
+    const rawIdBytes = new Uint8Array(
+      atob('cred+r1=').split('').map((c) => c.charCodeAt(0)),
+    );
     (navigator as unknown as { credentials: unknown }).credentials = {
       get: vi.fn(async () => ({
         id: 'cred-r1',
+        rawId: rawIdBytes.buffer,
         getClientExtensionResults: () => ({
           prf: { results: { first: new Uint8Array(32).buffer } },
         }),

--- a/client/src/pages/Onboarding/Onboarding.tsx
+++ b/client/src/pages/Onboarding/Onboarding.tsx
@@ -39,6 +39,8 @@ import {
   authenticatePasskey,
   prfOutputToBase64,
   decodeRecoveryKey,
+  arrayBufferToBase64Url,
+  base64UrlToArrayBuffer,
 } from '../../services/webauthn';
 import { refreshServerTokens, tryReconnectToCurrentServer } from '../../services/authReconnect';
 import { initCrypto, getIdentityKeys } from '../../services/crypto';
@@ -169,48 +171,46 @@ async function runPasskeyRecoveryFlow(args: {
     throw new Error('No passkey recovery slots found for this username.');
   }
 
-  let prfOutput: Uint8Array | null = null;
-  let credentialIdUsed = '';
+  // One get() with all candidate credentials + per-credential PRF salts.
+  // The authenticator silently filters to the credential it actually
+  // holds — so the user sees a single passkey prompt, ProtonPass /
+  // platform picker matches against the real credential ID in
+  // allowCredentials, and synthetic anti-enumeration descriptors are
+  // ignored without leaking which one is real.
+  setConnectLog((p) => [...p, { line: `  prompting for passkey · ${credentials.length} candidate(s)` }]);
+  const challenge = new Uint8Array(32);
+  crypto.getRandomValues(challenge);
+  const allowCredentials = credentials.map((desc) => ({
+    id: base64UrlToArrayBuffer(desc.credential_id) as unknown as BufferSource,
+    type: 'public-key' as const,
+  }));
+  const evalByCredential: Record<string, { first: Uint8Array }> = {};
   for (const desc of credentials) {
-    setConnectLog((p) => [...p, { line: `  trying passkey · ${desc.credential_id.slice(0, 12)}…` }]);
-    try {
-      const challenge = new Uint8Array(32);
-      crypto.getRandomValues(challenge);
-      const prfSaltBytes = fromBase64(desc.prf_salt);
-      const credentialIdBytes = fromBase64(desc.credential_id);
-      const assertion = await navigator.credentials.get({
-        publicKey: {
-          challenge: challenge as unknown as BufferSource,
-          rpId: rp_id,
-          allowCredentials: [{
-            id: credentialIdBytes as unknown as BufferSource,
-            type: 'public-key',
-          }],
-          userVerification: 'preferred',
-          extensions: { prf: { eval: { first: prfSaltBytes } } },
-        },
-      }) as PublicKeyCredential | null;
-      if (!assertion) continue;
-      const ext = (assertion.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } }).prf;
-      if (!ext?.results?.first) {
-        setConnectLog((p) => [...p, { line: '  passkey did not return PRF output · trying next', err: true }]);
-        continue;
-      }
-      prfOutput = new Uint8Array(ext.results.first);
-      credentialIdUsed = desc.credential_id;
-      break;
-    } catch (e) {
-      // NotAllowedError / InvalidStateError etc. — try the next
-      // descriptor. Real authenticators error out fast on
-      // credentials they don't hold.
-      setConnectLog((p) => [...p, { line: `  passkey rejected: ${(e as Error).message} · trying next` }]);
-      continue;
-    }
+    // evalByCredential keys MUST be base64url-encoded credential IDs
+    // per the WebAuthn PRF spec. Server descriptors are already in
+    // that form, but normalise through the decode/encode round-trip
+    // to strip padding and convert any STANDARD encodings.
+    const key = arrayBufferToBase64Url(base64UrlToArrayBuffer(desc.credential_id));
+    evalByCredential[key] = { first: fromBase64(desc.prf_salt) };
   }
-
-  if (!prfOutput) {
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      challenge: challenge as unknown as BufferSource,
+      rpId: rp_id,
+      allowCredentials,
+      userVerification: 'preferred',
+      extensions: { prf: { evalByCredential } },
+    },
+  })) as PublicKeyCredential | null;
+  if (!assertion) {
     throw new Error('No matching passkey found in your authenticator. Recovery failed.');
   }
+  const ext = (assertion.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } }).prf;
+  if (!ext?.results?.first) {
+    throw new Error("Authenticator didn't return a PRF output. Recovery requires a PRF-capable passkey.");
+  }
+  const prfOutput = new Uint8Array(ext.results.first);
+  const credentialIdUsed = arrayBufferToBase64Url(assertion.rawId);
 
   setConnectLog((p) => [...p, { line: '  ✓ passkey accepted · fetching encrypted blob' }]);
   const blobResp = await api.fetchRecoveryBlob(recoveryUrl, recoveryUsername, credentialIdUsed);

--- a/client/src/services/webauthn.ts
+++ b/client/src/services/webauthn.ts
@@ -231,7 +231,7 @@ export { decodeRecoveryKey } from './keyStore';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+export function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
   let binary = '';
   for (const byte of bytes) {
@@ -243,7 +243,7 @@ function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
   return b64.slice(0, end).replaceAll('+', '-').replaceAll('/', '_');
 }
 
-function base64UrlToArrayBuffer(base64url: string): ArrayBuffer {
+export function base64UrlToArrayBuffer(base64url: string): ArrayBuffer {
   const base64 = base64url.replaceAll('-', '+').replaceAll('_', '/');
   const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
   const binary = atob(padded);


### PR DESCRIPTION
## Summary

Two real-world bugs surfaced when running the passkey identity-recovery flow (design doc 15, PR #142) against a production ProtonPass-backed identity:

1. **`credential_id` decoded with the wrong base64 alphabet.** The server emits `URL_SAFE_NO_PAD` for both real and synthetic anti-enumeration descriptors, but the client was decoding with standard base64. `atob` threw "String contains an invalid character" on every `-`/`_`, so the loop skipped every descriptor and Firefox's WebAuthn fallback UI offered "Scan QR / Use Security key" instead of the passkey the user actually has.

2. **Per-descriptor loop made N separate `navigator.credentials.get` calls.** The synthetic descriptors are tried first; the authenticator rejects them one by one; by the time the real credential ID is offered the user has already seen three failed prompts. The right shape is a single `get()` with all candidate credentials in `allowCredentials` and a per-credential salt map via `prf.evalByCredential` — the platform picks the credential silently and prompts ProtonPass exactly once.

Exports `arrayBufferToBase64Url` + `base64UrlToArrayBuffer` from `services/webauthn` so the recovery flow can decode descriptors consistently with how `registerPasskey` originally encoded them.

## Test plan

- [x] `Onboarding.flows.test.tsx` — 15/15 passing, including the recovery happy-path / no-match / cancel cases (updated mocks to include `rawId` and the new webauthn exports).
- [x] Full vitest suite — 4414 passed / 157 skipped (5 pre-existing teardown errors in `ChatApp.deep-render.test.tsx`, unrelated).
- [ ] Manual verification on `dilla.thim.dev`: recovery flow on a wiped browser now prompts ProtonPass directly with the correct credential and restores the identity.