### PR TITLE
fix(onboarding): default recovery server URL to current origin

### DIFF
--- a/client/src/pages/Onboarding/Onboarding.tsx
+++ b/client/src/pages/Onboarding/Onboarding.tsx
@@ -477,7 +477,16 @@ export default function Onboarding() {
   // via the recovery key.
   const [useRecovery, setUseRecovery] = useState(searchParams.get('recover') === '1');
   const [usePasskeyRecovery, setUsePasskeyRecovery] = useState(searchParams.get('recover') === 'passkey');
-  const [recoveryServer, setRecoveryServer] = useState('');
+  // Recovery sub-flows reach the same server the page is loaded from
+  // by default — the passkey's rpId is bound to that origin anyway,
+  // so any other value would just fail later. Mirrors the same init
+  // as `server` above. Tauri users (origin = tauri://localhost) can
+  // still edit the field to point at a real remote.
+  const [recoveryServer, setRecoveryServer] = useState(
+    typeof globalThis !== 'undefined' && globalThis.location
+      ? globalThis.location.origin
+      : '',
+  );
   const [recoveryUsername, setRecoveryUsername] = useState('');
   const [recoveryKeyInput, setRecoveryKeyInput] = useState('');
 


### PR DESCRIPTION
## Summary

Bootstrap and invite modes already pre-fill the server URL from `window.location.origin`. The recovery and passkey-recovery sub-flows started with an empty field and a `http://localhost:8080` placeholder, which is the wrong default when the user loaded the page from a real server. The passkey's `rpId` is bound to the page origin anyway, so any other value just fails downstream.

Mirrors the same `useState` initializer the top-level `server` field already uses, so Tauri users (origin = `tauri://localhost`) can still edit the field manually to point at a real remote.

## Test plan

- [x] All 134 Onboarding tests still pass
- [ ] Visit `https://dilla.thim.dev/onboarding?mode=existing&recover=passkey` and confirm the Server URL field is pre-filled with `https://dilla.thim.dev`