### PR TITLE
fix(applayout): route reload bounce to sign-in when identity exists

### DIFF
--- a/client/src/pages/AppLayout.tsx
+++ b/client/src/pages/AppLayout.tsx
@@ -128,10 +128,24 @@ export default function AppLayout() {
 
   // Redirect to join/setup if no teams — wait until auth is validated so we
   // don't redirect during the brief window before persisted state is confirmed.
+  // If a local identity already exists, send the user to the sign-in mode
+  // so a reload with stale session state lands on the unlock form, not on
+  // the invite form (which would otherwise prompt the user to "join a new
+  // team" as if they were never enrolled).
   useEffect(() => {
-    if (authChecked && authTeams.size === 0) {
-      navigate('/join');
-    }
+    if (!authChecked || authTeams.size > 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { hasIdentity } = await import('../services/keyStore');
+        const exists = await hasIdentity();
+        if (cancelled) return;
+        navigate(exists ? '/onboarding?mode=existing' : '/join');
+      } catch {
+        if (!cancelled) navigate('/join');
+      }
+    })();
+    return () => { cancelled = true; };
   }, [authTeams, navigate, authChecked]);
   useIdentityBackup(activeTeamId, dataLoaded);
   usePresenceEvents(activeTeamId);


### PR DESCRIPTION
## Summary

AppLayout's \`teams.size === 0\` redirect went unconditionally to \`/join\`, which is aliased to \`/onboarding?mode=invite\`. So a fully-enrolled user whose sessionStorage hadn't restored yet on reload ended up staring at the **invite** form with a yellow "An identity already exists on this device" banner — instead of the **sign-in** form they actually need.

Probe \`hasIdentity()\` before bouncing: if the local IDB already has an \`EncryptedKeyFileV3\`, send the user to \`?mode=existing\` where the passkey / passphrase unlock UI is shown. Fully-fresh devices (no IDB identity) still route to \`/join\` as before.

## Test plan

- [x] 111/111 AppLayout tests pass
- [ ] On \`dilla.thim.dev\`, log in → reload → confirm the page now shows the passkey/passphrase unlock form (not the invite form)